### PR TITLE
Enable hazelcast upgrades with brew HZ-618

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -267,8 +267,7 @@ jobs:
           cd ../homebrew-hz
           git config --global user.name 'devOpsHazelcast'
           git config --global user.email 'devops@hazelcast.com'
-          git add Aliases
-          git add ${HZ_DISTRIBUTION}@${BREW_PACKAGE_VERSION}.rb
+          git add *.rb
           if [[ `git status --porcelain --untracked-files=no` ]]; then
             git commit -am "Hazelcast Homebrew Package ${{ env.PACKAGE_VERSION }} release"
             git pull --rebase

--- a/build-hazelcast-homebrew-package.sh
+++ b/build-hazelcast-homebrew-package.sh
@@ -63,7 +63,6 @@ sed -i "s+conflicts_with \".*\"$+conflicts_with \"$CONFLICTS\"+g" "${HZ_DISTRIBU
 if [[ ! ( ${HZ_VERSION} =~ ^.*+(SNAPSHOT|BETA|DR).*^ ) ]]; then
   HZ_MINOR_VERSION=$(echo "${HZ_VERSION}" | cut -c -3)
 
-  rm -f "${HZ_DISTRIBUTION}-${HZ_MINOR_VERSION}.rb"
   cp "${HZ_DISTRIBUTION}@${BREW_PACKAGE_VERSION}.rb" "${HZ_DISTRIBUTION}-${HZ_MINOR_VERSION}.rb"
 
   # Update 'hazelcast' or 'hazelcast-enterprise' alias
@@ -79,7 +78,6 @@ if [[ ! ( ${HZ_VERSION} =~ ^.*+(SNAPSHOT|BETA|DR).*^ ) ]]; then
   done
 
   if [ "${UPDATE_LATEST}" == "true" ]; then
-    rm -f "${HZ_DISTRIBUTION}.rb"
     cp "${HZ_DISTRIBUTION}@${BREW_PACKAGE_VERSION}.rb" "${HZ_DISTRIBUTION}.rb"
   fi
 fi

--- a/build-hazelcast-homebrew-package.sh
+++ b/build-hazelcast-homebrew-package.sh
@@ -69,7 +69,6 @@ if [[ ! ( ${HZ_VERSION} =~ ^.*+(SNAPSHOT|BETA|DR).*^ ) ]]; then
   # only if the version is greater than (new release) or equal to highest version
   UPDATE_LATEST="true"
   versions=("${HZ_DISTRIBUTION}"-[0-9]*\.rb)
-  cd ..
   for version in "${versions[@]}"
   do
     if [[ "$version" > "${HZ_DISTRIBUTION}-${HZ_MINOR_VERSION}.rb" ]]; then

--- a/build-hazelcast-homebrew-package.sh
+++ b/build-hazelcast-homebrew-package.sh
@@ -44,9 +44,11 @@ if [ ${HZ_DISTRIBUTION} == "hazelcast-enterprise" ]; then
   export CONFLICTS=hazelcast
 fi
 
-cd ../homebrew-hz || exit 1
+BREW_REPO_DIRECTORY=../homebrew-hz
 
-cp hazelcast@5.X.rb "${HZ_DISTRIBUTION}@${BREW_PACKAGE_VERSION}.rb"
+cp packages/brew/hazelcast-template.rb "${BREW_REPO_DIRECTORY}/${HZ_DISTRIBUTION}@${BREW_PACKAGE_VERSION}.rb"
+
+cd $BREW_REPO_DIRECTORY || exit 1
 
 # This version is used in `class HazelcastAT${VERSION_NODOTS}`, it must not have dots nor hyphens and must be CamelCased
 VERSION_NODOTS=$(echo "${BREW_PACKAGE_VERSION}" | tr '[:upper:]' '[:lower:]' | sed -r 's/(^|\.)(\w)/\U\2/g' | sed 's+\.++g')

--- a/build-hazelcast-homebrew-package.sh
+++ b/build-hazelcast-homebrew-package.sh
@@ -63,25 +63,24 @@ sed -i "s+conflicts_with \".*\"$+conflicts_with \"$CONFLICTS\"+g" "${HZ_DISTRIBU
 if [[ ! ( ${HZ_VERSION} =~ ^.*+(SNAPSHOT|BETA|DR).*^ ) ]]; then
   HZ_MINOR_VERSION=$(echo "${HZ_VERSION}" | cut -c -3)
 
-  rm -f "Aliases/${HZ_DISTRIBUTION}-${HZ_MINOR_VERSION}"
-  ln -s "../${HZ_DISTRIBUTION}@${BREW_PACKAGE_VERSION}.rb" "Aliases/${HZ_DISTRIBUTION}-${HZ_MINOR_VERSION}"
+  rm -f "${HZ_DISTRIBUTION}-${HZ_MINOR_VERSION}.rb"
+  cp "${HZ_DISTRIBUTION}@${BREW_PACKAGE_VERSION}.rb" "${HZ_DISTRIBUTION}-${HZ_MINOR_VERSION}.rb"
 
   # Update 'hazelcast' or 'hazelcast-enterprise' alias
   # only if the version is greater than (new release) or equal to highest version
   UPDATE_LATEST="true"
-  cd Aliases || exit
-  versions=("${HZ_DISTRIBUTION}"-[0-9]*)
+  versions=("${HZ_DISTRIBUTION}"-[0-9]*\.rb)
   cd ..
   for version in "${versions[@]}"
   do
-    if [[ "$version" > "${HZ_DISTRIBUTION}-${HZ_MINOR_VERSION}" ]]; then
+    if [[ "$version" > "${HZ_DISTRIBUTION}-${HZ_MINOR_VERSION}.rb" ]]; then
       UPDATE_LATEST="false"
     fi
   done
 
   if [ "${UPDATE_LATEST}" == "true" ]; then
-    rm "Aliases/${HZ_DISTRIBUTION}"
-    ln -s "../${HZ_DISTRIBUTION}@${BREW_PACKAGE_VERSION}.rb" "Aliases/${HZ_DISTRIBUTION}"
+    rm -f "${HZ_DISTRIBUTION}.rb"
+    cp "${HZ_DISTRIBUTION}@${BREW_PACKAGE_VERSION}.rb" "${HZ_DISTRIBUTION}.rb"
   fi
 fi
 

--- a/build-hazelcast-homebrew-package.sh
+++ b/build-hazelcast-homebrew-package.sh
@@ -65,6 +65,7 @@ sed -i "s+conflicts_with \".*\"$+conflicts_with \"$CONFLICTS\"+g" "${HZ_DISTRIBU
 if [[ ! ( ${HZ_VERSION} =~ ^.*+(SNAPSHOT|BETA|DR).*^ ) ]]; then
   HZ_MINOR_VERSION=$(echo "${HZ_VERSION}" | cut -c -3)
 
+  rm -f "Aliases/${HZ_DISTRIBUTION}-${HZ_MINOR_VERSION}" #migrate incrementally from symlinks to regular files
   cp "${HZ_DISTRIBUTION}@${BREW_PACKAGE_VERSION}.rb" "${HZ_DISTRIBUTION}-${HZ_MINOR_VERSION}.rb"
 
   # Update 'hazelcast' or 'hazelcast-enterprise' alias
@@ -79,6 +80,7 @@ if [[ ! ( ${HZ_VERSION} =~ ^.*+(SNAPSHOT|BETA|DR).*^ ) ]]; then
   done
 
   if [ "${UPDATE_LATEST}" == "true" ]; then
+    rm -f "Aliases/${HZ_DISTRIBUTION}" #migrate incrementally from symlinks to regular files
     cp "${HZ_DISTRIBUTION}@${BREW_PACKAGE_VERSION}.rb" "${HZ_DISTRIBUTION}.rb"
   fi
 fi

--- a/packages/brew/hazelcast-template.rb
+++ b/packages/brew/hazelcast-template.rb
@@ -1,0 +1,36 @@
+class HazelcastAT5X < Formula
+    desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
+    homepage "https://github.com/hazelcast/hazelcast-command-line"
+    url "https://github.com/hazelcast/hazelcast-command-line/releases/download/v5.2021.07.1/hazelcast-5.0-BETA-1.tar.gz"
+    sha256 "f108d22a1aec61bbd637f89ff522af7d9861ef13afcfad24a5095127f04f091d"
+    conflicts_with "hazelcast-enterprise", because: "You can install either hazelcast (open source under Apache 2) or hazelcast-enterprise (under Hazelcast license)"
+  
+    depends_on "openjdk" => :recommended
+
+    def install
+      libexec.install Dir["*"]
+      Dir["#{libexec}/bin/hz*"].each do |path|
+        executable_name = File.basename(path)
+        if executable_name.end_with? ".bat"
+          next
+        end
+        (bin/executable_name).write_env_script libexec/"bin/#{executable_name}", Language::Java.overridable_java_home_env
+      end
+      etc.install "#{libexec}/config" => "hazelcast"
+      rm_rf libexec/"config"
+      libexec.install_symlink "#{etc}/hazelcast" => "config"
+      prefix.install_metafiles
+      inreplace libexec/"lib/hazelcast-download.properties", "hazelcastDownloadId=distribution", "hazelcastDownloadId=brew"
+    end
+
+    def caveats
+        <<~EOS
+          Configuration files have been placed in #{etc}/hazelcast.
+        EOS
+      end
+  
+    def post_install
+      exec "echo Hazelcast has been installed."
+    end
+
+  end


### PR DESCRIPTION
This PR adds support for upgrading brew packages of hazelcast distributions. Upgrades will work for all installation of formulas generated/updated after the merge if this PR

Related to: https://hazelcast.atlassian.net/browse/HZ-618
Counterpart in `hazelcast/hz` (template files removal): https://github.com/hazelcast/homebrew-hz/pull/26 

Be aware that upgrades work only across a single formula name, i.e. `hazelcast`, `hazelcast-5.0` and `hazelcast@5.0.2` are completely independent formulas, so you can install all of them at the same time, also upgrading one of them won't affect other installations (except config files of course).

Symlinks will be incrementally migrated to regular files on each release to make current CI jobs successful. After merging this PR, we can asynchronously (and manually) migrate untouched symlinks.

## Testing

### CI build

You can check the generated commits in `hazelcast/hz-test` repository:
- https://github.com/hazelcast/homebrew-hz-test/commit/a675f0b747a25fc89673b9950512b5a4d276c90d
- https://github.com/hazelcast/homebrew-hz-test/commit/a675f0b747a25fc89673b9950512b5a4d276c90d

Symlinks were replaced by regular files.

### Manual tests

Created and pushed a commit setting `hazelcast-distribution-5.1-20220218.132537-412.tar.gz` in `hazelcast.rb`

Added tap `hazelcast/hz-test` and installed hazelcast
```
brew tap hazelcast/hz-test
brew install hazelcast
==> Downloading https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-distribution/5.1-SNAPSHOT/hazelcast-distribution-5.1-20220218.132537-412.tar.gz
######################################################################## 100.0%
==> Installing hazelcast from hazelcast/hz-test
Hazelcast has been installed.
==> Caveats
Configuration files have been placed in /usr/local/etc/hazelcast.
==> Summary
🍺  /usr/local/Cellar/hazelcast/20220218.132537-412: 65 files, 393.2MB, built in 5 seconds
```

Modified cluster name to `custom-name` in `/usr/local/etc/hazelcast/hazelcast.xml` and verified the change by running `hz start`

Created and pushed a commit setting `hazelcast-distribution-5.1-20220221.105811-413.tar.gz` in `hazelcast.rb`

Run `brew update` to refresh taps:

```
brew update
Updated 1 tap (hazelcast/hz-test).
==> Updated Formulae
hazelcast/hz-test/hazelcast ✔
```

Run `brew outdated` to see the details:
```
brew outdated
...
hazelcast/hz-test/hazelcast (20220218.132537-412) < 20220221.105811-413
...
```

Run `brew upgrade hazelcast` to install the newest version of hazelcast:

```
brew upgrade hazelcast
==> Upgrading 1 outdated package:
hazelcast/hz-test/hazelcast 20220218.132537-412 -> 20220221.105811-413
==> Downloading https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-distribution/5.1-SNAPSHOT/hazelcast-distribution-5.1-20220221.105811-413.tar.gz
Already downloaded: /Users/ldziedziul/Library/Caches/Homebrew/downloads/11ccfd1e424f46b8f90d18cfaa04304e09a080f21bfac0d4de4dd5dc91ded2cb--hazelcast-distribution-5.1-20220221.105811-413.tar.gz
==> Upgrading hazelcast/hz-test/hazelcast
  20220218.132537-412 -> 20220221.105811-413

Hazelcast has been installed.
==> Caveats
Configuration files have been placed in /usr/local/etc/hazelcast.
==> Summary
🍺  /usr/local/Cellar/hazelcast/20220221.105811-413: 65 files, 393.2MB, built in 4 seconds
```

Run `hz start` to confirm that configuration was persisted and cluster name is set to `custom-name`

At the very end I've reset `hazelcast/homebrew-hz-test` to the original HEAD

