### PR TITLE
Use revision/release version for deb/rpm

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -128,7 +128,7 @@ jobs:
           source ./common.sh
           wget -qO - https://repository.hazelcast.com/api/gpg/key/public | sudo apt-key add -
           echo "deb ${DEBIAN_REPO_BASE_URL} ${PACKAGE_REPO} main" | sudo tee -a /etc/apt/sources.list
-          sudo apt update && sudo apt install ${{ env.HZ_DISTRIBUTION}}=${{ env.PACKAGE_VERSION }}
+          sudo apt update && sudo apt install ${{ env.HZ_DISTRIBUTION}}=${DEB_PACKAGE_VERSION}
           HAZELCAST_CONFIG="$(pwd)/config/integration-test-hazelcast.yaml" hz-start > hz.log 2>&1 &
 
       - name: Check Hazelcast health

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -128,7 +128,7 @@ jobs:
           source ./common.sh
           wget -qO - https://repository.hazelcast.com/api/gpg/key/public | sudo apt-key add -
           echo "deb ${DEBIAN_REPO_BASE_URL} ${PACKAGE_REPO} main" | sudo tee -a /etc/apt/sources.list
-          sudo apt update && sudo apt install ${{ env.HZ_DISTRIBUTION}}=${DEB_PACKAGE_VERSION}
+          sudo apt update && sudo apt install ${{ env.HZ_DISTRIBUTION}}=${HZ_VERSION}
           HAZELCAST_CONFIG="$(pwd)/config/integration-test-hazelcast.yaml" hz-start > hz.log 2>&1 &
 
       - name: Check Hazelcast health
@@ -139,6 +139,14 @@ jobs:
         run: |
           source ./common.sh
           sudo apt remove ${{ env.HZ_DISTRIBUTION}}
+
+      - name: Remove deb package from test repo
+        if: always()
+        run: |
+          source ./common.sh
+          curl -H "Authorization: Bearer ${{ secrets.ARTIFACTORY_SECRET }}" \
+            -X DELETE \
+            "$DEBIAN_REPO_BASE_URL/${HZ_DISTRIBUTION}-${DEB_PACKAGE_VERSION}-all.deb"
 
   rpm:
     runs-on: ubuntu-latest
@@ -205,6 +213,14 @@ jobs:
         run: |
           source ./common.sh
           yum remove -y ${{ env.HZ_DISTRIBUTION}}-${RPM_PACKAGE_VERSION}
+
+      - name: Remove rpm package from test repo
+        if: always()
+        run: |
+          source ./common.sh
+          curl -H "Authorization: Bearer ${{ secrets.ARTIFACTORY_SECRET }}" \
+            -X DELETE \
+            "$RPM_REPO_BASE_URL/${PACKAGE_REPO}/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm"
 
   homebrew:
     runs-on: macos-latest

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -141,7 +141,7 @@ jobs:
           sudo apt remove ${{ env.HZ_DISTRIBUTION}}
 
       - name: Remove deb package from test repo
-        if: always()
+        if: github.event_name == 'pull_request'
         run: |
           source ./common.sh
           curl -H "Authorization: Bearer ${{ secrets.ARTIFACTORY_SECRET }}" \
@@ -215,7 +215,7 @@ jobs:
           yum remove -y ${{ env.HZ_DISTRIBUTION}}-${RPM_PACKAGE_VERSION}
 
       - name: Remove rpm package from test repo
-        if: always()
+        if: github.event_name == 'pull_request'
         run: |
           source ./common.sh
           curl -H "Authorization: Bearer ${{ secrets.ARTIFACTORY_SECRET }}" \

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -202,7 +202,7 @@ jobs:
           source ./common.sh
           wget ${RPM_REPO_BASE_URL}/${PACKAGE_REPO}/hazelcast-rpm-${PACKAGE_REPO}.repo -O hazelcast-rpm-${PACKAGE_REPO}.repo
           mv hazelcast-rpm-${PACKAGE_REPO}.repo /etc/yum.repos.d/          
-          yum install -y ${{ env.HZ_DISTRIBUTION}}-${RPM_PACKAGE_VERSION}
+          yum install -y ${{ env.HZ_DISTRIBUTION}}-${RPM_HZ_VERSION}
           HAZELCAST_CONFIG="$(pwd)/config/integration-test-hazelcast.yaml" hz-start > hz.log 2>&1 &
 
       - name: Check Hazelcast health

--- a/build-hazelcast-deb-package.sh
+++ b/build-hazelcast-deb-package.sh
@@ -26,7 +26,7 @@ fi
 
 source common.sh
 
-echo "Building DEB package $HZ_DISTRIBUTION:${HZ_VERSION} package version ${PACKAGE_VERSION}"
+echo "Building DEB package $HZ_DISTRIBUTION:${HZ_VERSION} package version ${DEB_PACKAGE_VERSION}"
 
 # Remove previous build, useful on local
 rm -rf build/deb
@@ -58,7 +58,7 @@ cp -RT packages/deb/hazelcast/usr/lib/hazelcast build/deb/hazelcast/usr/lib/haze
 
 dpkg-deb --build build/deb/hazelcast
 
-DEB_FILE=${HZ_DISTRIBUTION}-${PACKAGE_VERSION}-all.deb
+DEB_FILE=${HZ_DISTRIBUTION}-${DEB_PACKAGE_VERSION}-all.deb
 mv build/deb/hazelcast.deb "$DEB_FILE"
 
 if [ "${PUBLISH}" == "true" ]; then

--- a/build-hazelcast-rpm-package.sh
+++ b/build-hazelcast-rpm-package.sh
@@ -28,7 +28,7 @@ fi
 
 source common.sh
 
-echo "Building RPM package $HZ_DISTRIBUTION:${HZ_VERSION} package version ${PACKAGE_VERSION}"
+echo "Building RPM package $HZ_DISTRIBUTION:${HZ_VERSION} package version ${RPM_PACKAGE_VERSION}"
 
 # Remove previous build, useful on local
 rm -rf build/rpmbuild
@@ -61,22 +61,22 @@ gpg-connect-agent reloadagent /bye
 $GPG_PRESET_PASSPHRASE --passphrase ${BINTRAY_PASSPHRASE} --preset 50907674C38F9E099C35345E246EBBA203D8E107
 rpmbuild --define "_topdir $(realpath build/rpmbuild)" -bb build/rpmbuild/rpm/hazelcast.spec
 
-rpm --define "_gpg_name deploy@hazelcast.com" --addsign build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}-1.noarch.rpm
+rpm --define "_gpg_name deploy@hazelcast.com" --addsign build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm
 
 if [ "${PUBLISH}" == "true" ]; then
-  RPM_SHA256SUM=$(sha256sum "build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}-1.noarch.rpm" | cut -d ' ' -f 1)
-  RPM_SHA1SUM=$(sha1sum "build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}-1.noarch.rpm" | cut -d ' ' -f 1)
-  RPM_MD5SUM=$(md5sum "build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}-1.noarch.rpm" | cut -d ' ' -f 1)
+  RPM_SHA256SUM=$(sha256sum "build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm" | cut -d ' ' -f 1)
+  RPM_SHA1SUM=$(sha1sum "build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm" | cut -d ' ' -f 1)
+  RPM_MD5SUM=$(md5sum "build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm" | cut -d ' ' -f 1)
 
   # Delete any package that exists - previous version of the same package
   curl -H "Authorization: Bearer ${ARTIFACTORY_SECRET}" \
     -X DELETE \
-    "$RPM_REPO_BASE_URL/${PACKAGE_REPO}/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}-1.noarch.rpm"
+    "$RPM_REPO_BASE_URL/${PACKAGE_REPO}/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm"
 
   curl -H "Authorization: Bearer ${ARTIFACTORY_SECRET}" -H "X-Checksum-Deploy: false" -H "X-Checksum-Sha256: $RPM_SHA256SUM" \
     -H "X-Checksum-Sha1: $RPM_SHA1SUM" -H "X-Checksum-MD5: $RPM_MD5SUM" \
-    -T"build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}-1.noarch.rpm" \
+    -T"build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm" \
     -X PUT \
-    "$RPM_REPO_BASE_URL/${PACKAGE_REPO}/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}-1.noarch.rpm"
+    "$RPM_REPO_BASE_URL/${PACKAGE_REPO}/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm"
 
 fi

--- a/common.sh
+++ b/common.sh
@@ -36,7 +36,9 @@ DEB_PACKAGE_VERSION="$HZ_VERSION"-$RELEASE_VERSION
 export DEB_PACKAGE_VERSION
 
 # For RPM the upstream version part must not contain -, use `.` instead of `-`
-RPM_PACKAGE_VERSION=$(echo $HZ_VERSION | sed -r -r 's/(-)/\./g')-$RELEASE_VERSION
+RPM_HZ_VERSION=$(echo $HZ_VERSION | sed -r -r 's/(-)/\./g')
+export RPM_HZ_VERSION
+RPM_PACKAGE_VERSION=$RPM_HZ_VERSION-$RELEASE_VERSION
 export RPM_PACKAGE_VERSION
 
 # For brew the version is lowercase and with `.` instead of `-`

--- a/common.sh
+++ b/common.sh
@@ -23,15 +23,15 @@ RELEASE_VERSION=${PACKAGE_VERSION#"$HZ_VERSION"}
 RELEASE_VERSION=${RELEASE_VERSION#-}
 
 if [ -z "$RELEASE_VERSION" ]; then
-  # Default to 0 if not set
-  RELEASE_VERSION=0
+  # Default to 1 if not set
+  RELEASE_VERSION=1
 fi
 export RELEASE_VERSION
 
 # See https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
 # "if it (= debian revision) isn’t present then the upstream_version must not contain a hyphen"
 # So if our upstream version contains hyphen, e.g. 5.2-DR8, the deb package version should be 5.2-DR8-1
-# For simplicity we add it in all cases, default to 0 when not specified in PACKAGE_VERSION
+# For simplicity we add it in all cases, default to 1 when not specified in PACKAGE_VERSION
 DEB_PACKAGE_VERSION="$HZ_VERSION"-$RELEASE_VERSION
 export DEB_PACKAGE_VERSION
 

--- a/common.sh
+++ b/common.sh
@@ -13,13 +13,35 @@ if [[ "$HZ_VERSION" == *"BETA"* ]]; then
   export PACKAGE_REPO=beta
 fi
 
+# Extract release version from package version - release version is the version part specific to the package
+
+# Remove HZ_VERSION prefix from PACKAGE_VERSION,
+# e.g. HZ_VERSION=5.1-DR8,PACKAGE_VERSION=5.1-DR8-1 -> -1
+RELEASE_VERSION=${PACKAGE_VERSION#"$HZ_VERSION"}
+
+# Remove '-' from RELEASE_VERSION
+RELEASE_VERSION=${RELEASE_VERSION#-}
+
+if [ -z "$RELEASE_VERSION" ]; then
+  # Default to 0 if not set
+  RELEASE_VERSION=0
+fi
+export RELEASE_VERSION
+
+# See https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
+# "if it (= debian revision) isn’t present then the upstream_version must not contain a hyphen"
+# So if our upstream version contains hyphen, e.g. 5.2-DR8, the deb package version should be 5.2-DR8-1
+# For simplicity we add it in all cases, default to 0 when not specified in PACKAGE_VERSION
+DEB_PACKAGE_VERSION="$HZ_VERSION"-$RELEASE_VERSION
+export DEB_PACKAGE_VERSION
+
+# For RPM the upstream version part must not contain -, use `.` instead of `-`
+RPM_PACKAGE_VERSION=$(echo $HZ_VERSION | sed -r -r 's/(-)/\./g')-$RELEASE_VERSION
+export RPM_PACKAGE_VERSION
+
 # For brew the version is lowercase and with `.` instead of `-`
 BREW_PACKAGE_VERSION=$(echo $PACKAGE_VERSION | tr '[:upper:]' '[:lower:]' | sed -r -r 's/(-)/\./g')
 export BREW_PACKAGE_VERSION
-
-# For RPM the version is with `.` instead of `-`
-RPM_PACKAGE_VERSION=$(echo $PACKAGE_VERSION | sed -r -r 's/(-)/\./g')
-export RPM_PACKAGE_VERSION
 
 if [ "${EVENT_NAME}" == "pull_request" ]; then
   # PRs publish to test repositories and install the packages from there

--- a/packages/rpm/hazelcast.spec
+++ b/packages/rpm/hazelcast.spec
@@ -1,11 +1,13 @@
 %define hzversion ${HZ_VERSION}
+%define rpmhzversion ${RPM_HZ_VERSION}
+%define releaseversion ${RELEASE_VERSION}
 %define hzdistribution ${HZ_DISTRIBUTION}
 %define debug_package %{nil}
 
 Name:       %{hzdistribution}
-Version:    ${RPM_PACKAGE_VERSION}
+Version:    %{rpmhzversion}
 Epoch:      1
-Release:    1
+Release:    %{releaseversion}
 Summary:    Hazelcast is a streaming and memory-first application platform.
 
 License:    ASL 2.0

--- a/test_common.sh
+++ b/test_common.sh
@@ -16,10 +16,10 @@ function test_versions() {
 }
 
 #             HZ_VERSION     PACKAGE_VERSION DEB_PACKAGE_VERSION RPM_PACKAGE_VERSION
-test_versions "5.0.2"        "5.0.2"         "5.0.2-0"           "5.0.2-0"
+test_versions "5.0.2"        "5.0.2"         "5.0.2-1"           "5.0.2-1"
 test_versions "5.0.2"        "5.0.2-1"       "5.0.2-1"           "5.0.2-1"
-test_versions "5.1"          "5.1"           "5.1-0"             "5.1-0"
+test_versions "5.1"          "5.1"           "5.1-1"             "5.1-1"
 test_versions "5.1"          "5.1-1"         "5.1-1"             "5.1-1"
-test_versions "5.1-SNAPSHOT" "5.1-SNAPSHOT"  "5.1-SNAPSHOT-0"    "5.1.SNAPSHOT-0"
-test_versions "5.1-BETA-1"   "5.1-BETA-1"    "5.1-BETA-1-0"      "5.1.BETA.1-0"
+test_versions "5.1-SNAPSHOT" "5.1-SNAPSHOT"  "5.1-SNAPSHOT-1"    "5.1.SNAPSHOT-1"
+test_versions "5.1-BETA-1"   "5.1-BETA-1"    "5.1-BETA-1-1"      "5.1.BETA.1-1"
 test_versions "5.1-BETA-1"   "5.1-BETA-1-2"  "5.1-BETA-1-2"      "5.1.BETA.1-2"

--- a/test_common.sh
+++ b/test_common.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+function test_versions() {
+  export HZ_VERSION=$1
+  export PACKAGE_VERSION=$2
+  echo "Test HZ_VERSION=$HZ_VERSION PACKAGE_VERSION=$PACKAGE_VERSION"
+
+  source ./common.sh
+
+  if [[ $DEB_PACKAGE_VERSION == "$3" && $RPM_PACKAGE_VERSION == "$4" ]]; then
+    PASSED=yes
+  else
+    PASSED=no
+  fi
+  echo "Result RELEASE_VERSION=$RELEASE_VERSION, DEB=$DEB_PACKAGE_VERSION, RPM=$RPM_PACKAGE_VERSION, PASSED=$PASSED"
+}
+
+#             HZ_VERSION     PACKAGE_VERSION DEB_PACKAGE_VERSION RPM_PACKAGE_VERSION
+test_versions "5.0.2"        "5.0.2"         "5.0.2-0"           "5.0.2-0"
+test_versions "5.0.2"        "5.0.2-1"       "5.0.2-1"           "5.0.2-1"
+test_versions "5.1"          "5.1"           "5.1-0"             "5.1-0"
+test_versions "5.1"          "5.1-1"         "5.1-1"             "5.1-1"
+test_versions "5.1-SNAPSHOT" "5.1-SNAPSHOT"  "5.1-SNAPSHOT-0"    "5.1.SNAPSHOT-0"
+test_versions "5.1-BETA-1"   "5.1-BETA-1"    "5.1-BETA-1-0"      "5.1.BETA.1-0"
+test_versions "5.1-BETA-1"   "5.1-BETA-1-2"  "5.1-BETA-1-2"      "5.1.BETA.1-2"


### PR DESCRIPTION
This allows us to publish same version of Hazelcast with newer version
of the package, e.g. 5.0.2-2

For deb we weren't following the guidelines - some our versions contained
hyphen when debian revision was missing - fixed by using debian revision
everywhere (defaults to 1).