### PR TITLE
Release nonstable meta-releases

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -246,9 +246,9 @@ jobs:
           sha256sum --version
           echo "PATH=/usr/local/opt/coreutils/libexec/gnubin:/usr/local/opt/gnu-sed/libexec/gnubin:$PATH" >> $GITHUB_ENV
 
-      - name: Run brew tests
+      - name: Run script tests
         run: |
-          packages/brew/test_brew_functions.sh
+          ./test.sh
 
       - name: Setup JDK
         uses: actions/setup-java@v1

--- a/common.sh
+++ b/common.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 
-set -x
-
-export PACKAGE_REPO=stable
+export RELEASE_TYPE=stable
 if [[ "$HZ_VERSION" == *"SNAPSHOT"* ]]; then
-  export PACKAGE_REPO=snapshot
+  export RELEASE_TYPE=snapshot
 fi
 if [[ "$HZ_VERSION" == *"DR"* ]]; then
-  export PACKAGE_REPO=devel
+  export RELEASE_TYPE=devel
 fi
 if [[ "$HZ_VERSION" == *"BETA"* ]]; then
-  export PACKAGE_REPO=beta
+  export RELEASE_TYPE=beta
 fi
+export PACKAGE_REPO=$RELEASE_TYPE
 
 # Extract release version from package version - release version is the version part specific to the package
 

--- a/packages/brew/functions.sh
+++ b/packages/brew/functions.sh
@@ -1,13 +1,5 @@
 #!/usr/bin/env bash
 
-function isReleaseVersion {
-   local version=$1
-   if [[ ! ( ${version} =~ ^.*(SNAPSHOT|BETA|DR).*$ ) ]]; then
-     return
-   fi
-   false
-}
-
 function alphanumCamelCase {
   echo "$1"|  sed -r 's/(-)/\./g' | tr '[:upper:]' '[:lower:]' | sed "s/\b\(.\)/\u\1/g" | sed 's+\.++g'
 }

--- a/packages/brew/test_brew_functions.sh
+++ b/packages/brew/test_brew_functions.sh
@@ -28,26 +28,6 @@ findScriptDir
 
 TESTS_RESULT=0
 
-function assertNotReleaseVersion {
-  local version=$1
-  isReleaseVersion "$version"
-  assert_eq 1 $? "Version $version should not be a release version" || TESTS_RESULT=$?
-}
-
-function assertReleaseVersion {
-  local version=$1
-  isReleaseVersion "$version"
-  assert_eq 0 "$?" "Version $version should be a release version" || TESTS_RESULT=$?
-}
-
-log_header "Tests for isReleaseVersion"
-assertNotReleaseVersion "5.2-SNAPSHOT"
-assertNotReleaseVersion "5.2-BETA-1"
-assertNotReleaseVersion "5.1-DR8"
-assertReleaseVersion "5.0"
-assertReleaseVersion "5.1"
-assertReleaseVersion "5.1.1"
-
 function assertAlphanumCamelCase {
   local testValue=$1
   local expected=$2
@@ -62,6 +42,9 @@ assertAlphanumCamelCase "5.1-DR8" "51Dr8"
 assertAlphanumCamelCase "5.2" "52"
 assertAlphanumCamelCase "5.2.1" "521"
 assertAlphanumCamelCase "" ""
+assertAlphanumCamelCase "snapshot" "Snapshot"
+assertAlphanumCamelCase "beta" "Beta"
+assertAlphanumCamelCase "dr" "Dr"
 
 function assertBrewClass {
   local distribution=$1

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+function findScriptDir() {
+  CURRENT=$PWD
+
+  DIR=$(dirname "$0")
+  cd "$DIR" || exit
+  TARGET_FILE=$(basename "$0")
+
+  # Iterate down a (possible) chain of symlinks
+  while [ -L "$TARGET_FILE" ]
+  do
+      TARGET_FILE=$(readlink "$TARGET_FILE")
+      DIR=$(dirname "$TARGET_FILE")
+      cd "$DIR" || exit
+      TARGET_FILE=$(basename "$TARGET_FILE")
+  done
+
+  SCRIPT_DIR=$(pwd -P)
+  # Restore current directory
+  cd "$CURRENT" || exit
+}
+
+findScriptDir
+
+find "$SCRIPT_DIR" -name "test_*.sh" -print0 | xargs -0 -n1 bash

--- a/test_common.sh
+++ b/test_common.sh
@@ -1,25 +1,65 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-function test_versions() {
-  export HZ_VERSION=$1
-  export PACKAGE_VERSION=$2
-  echo "Test HZ_VERSION=$HZ_VERSION PACKAGE_VERSION=$PACKAGE_VERSION"
+function findScriptDir() {
+  CURRENT=$PWD
 
-  source ./common.sh
+  DIR=$(dirname "$0")
+  cd "$DIR" || exit
+  TARGET_FILE=$(basename "$0")
 
-  if [[ $DEB_PACKAGE_VERSION == "$3" && $RPM_PACKAGE_VERSION == "$4" ]]; then
-    PASSED=yes
-  else
-    PASSED=no
-  fi
-  echo "Result RELEASE_VERSION=$RELEASE_VERSION, DEB=$DEB_PACKAGE_VERSION, RPM=$RPM_PACKAGE_VERSION, PASSED=$PASSED"
+  # Iterate down a (possible) chain of symlinks
+  while [ -L "$TARGET_FILE" ]
+  do
+      TARGET_FILE=$(readlink "$TARGET_FILE")
+      DIR=$(dirname "$TARGET_FILE")
+      cd "$DIR" || exit
+      TARGET_FILE=$(basename "$TARGET_FILE")
+  done
+
+  SCRIPT_DIR=$(pwd -P)
+  # Restore current directory
+  cd "$CURRENT" || exit
 }
 
-#             HZ_VERSION     PACKAGE_VERSION DEB_PACKAGE_VERSION RPM_PACKAGE_VERSION
-test_versions "5.0.2"        "5.0.2"         "5.0.2-1"           "5.0.2-1"
-test_versions "5.0.2"        "5.0.2-1"       "5.0.2-1"           "5.0.2-1"
-test_versions "5.1"          "5.1"           "5.1-1"             "5.1-1"
-test_versions "5.1"          "5.1-1"         "5.1-1"             "5.1-1"
-test_versions "5.1-SNAPSHOT" "5.1-SNAPSHOT"  "5.1-SNAPSHOT-1"    "5.1.SNAPSHOT-1"
-test_versions "5.1-BETA-1"   "5.1-BETA-1"    "5.1-BETA-1-1"      "5.1.BETA.1-1"
-test_versions "5.1-BETA-1"   "5.1-BETA-1-2"  "5.1-BETA-1-2"      "5.1.BETA.1-2"
+findScriptDir
+
+. "$SCRIPT_DIR"/packages/tests-common/assert.sh/assert.sh
+. "$SCRIPT_DIR"/common.sh
+
+TESTS_RESULT=0
+
+function assertReleaseType {
+  export HZ_VERSION=$1
+  local expected=$2
+  . "$SCRIPT_DIR"/common.sh
+  assert_eq $expected $RELEASE_TYPE "Version $HZ_VERSION should not a $expected release" || TESTS_RESULT=$?
+}
+
+log_header "Tests for RELEASE_TYPE"
+assertReleaseType "5.2-SNAPSHOT" "snapshot"
+assertReleaseType "5.2-BETA-1" "beta"
+assertReleaseType "5.1-DR8" "devel"
+assertReleaseType "5.0" "stable"
+assertReleaseType "5.1" "stable"
+assertReleaseType "5.1.1" "stable"
+
+function assertPackageVersions {
+  export HZ_VERSION=$1
+  export PACKAGE_VERSION=$2
+  local expectedDebVersion=$3
+  local expectedRpmVersion=$4
+  . "$SCRIPT_DIR"/common.sh
+  assert_eq "$expectedDebVersion" "$DEB_PACKAGE_VERSION" "DEB_PACKAGE_VERSION for (HZ_VERSION=$HZ_VERSION, PACKAGE_VERSION=$PACKAGE_VERSION) should be $expectedDebVersion" || TESTS_RESULT=$?
+  assert_eq "$expectedRpmVersion" "$RPM_PACKAGE_VERSION" "RPM_PACKAGE_VERSION for (HZ_VERSION=$HZ_VERSION, PACKAGE_VERSION=$PACKAGE_VERSION) should be $expectedRpmVersion" || TESTS_RESULT=$?
+}
+
+log_header "Tests for DEB_PACKAGE_VERSION and RPM_PACKAGE_VERSION"
+assertPackageVersions "5.0.2"        "5.0.2"         "5.0.2-1"           "5.0.2-1"
+assertPackageVersions "5.0.2"        "5.0.2-1"       "5.0.2-1"           "5.0.2-1"
+assertPackageVersions "5.1"          "5.1"           "5.1-1"             "5.1-1"
+assertPackageVersions "5.1"          "5.1-1"         "5.1-1"             "5.1-1"
+assertPackageVersions "5.1-SNAPSHOT" "5.1-SNAPSHOT"  "5.1-SNAPSHOT-1"    "5.1.SNAPSHOT-1"
+assertPackageVersions "5.1-BETA-1"   "5.1-BETA-1"    "5.1-BETA-1-1"      "5.1.BETA.1-1"
+assertPackageVersions "5.1-BETA-1"   "5.1-BETA-1-2"  "5.1-BETA-1-2"      "5.1.BETA.1-2"
+
+assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/test_common.sh
+++ b/test_common.sh
@@ -32,7 +32,7 @@ function assertReleaseType {
   export HZ_VERSION=$1
   local expected=$2
   . "$SCRIPT_DIR"/common.sh
-  assert_eq $expected $RELEASE_TYPE "Version $HZ_VERSION should not a $expected release" || TESTS_RESULT=$?
+  assert_eq $expected $RELEASE_TYPE "Version $HZ_VERSION should be a $expected release" || TESTS_RESULT=$?
 }
 
 log_header "Tests for RELEASE_TYPE"


### PR DESCRIPTION
Added support for generating nonstable brew meta packages: `hazelcast-snapshot`, `hazelcast-devel`, `hazelcast-beta`

Added tests of common.sh to the CI workflow. In general any `test_*.sh` file will be picked up and run as a part of the workflow
