### PR TITLE
Allow to build only a single package type

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -17,16 +17,16 @@ on:
       HZ_VERSION:
         description: 'Version of Hazelcast to build the image for, this is the Maven version - e.g.: 5.0.2 or 5.1-SNAPSHOT'
         required: true
-       package_types:
-         description: 'Packages to build'
-         required: true
-         default: 'all'
-         type: choice
-         options:
-         - all
-         - deb
-         - rpm
-         - homebrew
+      package_types:
+        description: 'Packages to build'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+        - all
+        - deb
+        - rpm
+        - homebrew
 
 env:
   EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -87,7 +87,7 @@ jobs:
 
   deb:
     runs-on: ubuntu-latest
-    if: env.PACKAGE_TYPES == 'all' || env.PACKAGE_TYPES == 'deb'
+    if: ${{ env.PACKAGE_TYPES == 'all' || env.PACKAGE_TYPES == 'deb' }}
     strategy:
       fail-fast: false
       matrix:
@@ -155,7 +155,7 @@ jobs:
 
   rpm:
     runs-on: ubuntu-latest
-    if: env.PACKAGE_TYPES == 'all' || env.PACKAGE_TYPES == 'rpm'
+    if: ${{ env.PACKAGE_TYPES == 'all' || env.PACKAGE_TYPES == 'rpm' }}
     container: rockylinux:latest
     strategy:
       fail-fast: false
@@ -230,7 +230,7 @@ jobs:
 
   homebrew:
     runs-on: macos-latest
-    if: env.PACKAGE_TYPES == 'all' || env.PACKAGE_TYPES == 'homebrew'
+    if: ${{ env.PACKAGE_TYPES == 'all' || env.PACKAGE_TYPES == 'homebrew' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -17,6 +17,16 @@ on:
       HZ_VERSION:
         description: 'Version of Hazelcast to build the image for, this is the Maven version - e.g.: 5.0.2 or 5.1-SNAPSHOT'
         required: true
+       package_types:
+         description: 'Packages to build'
+         required: true
+         default: 'all'
+         type: choice
+         options:
+         - all
+         - deb
+         - rpm
+         - homebrew
 
 env:
   EVENT_NAME: ${{ github.event_name }}
@@ -76,6 +86,7 @@ jobs:
 
   deb:
     runs-on: ubuntu-latest
+    if: github.event.inputs.package_types == 'all' || github.event.inputs.package_types == 'deb'
     strategy:
       fail-fast: false
       matrix:
@@ -143,6 +154,7 @@ jobs:
 
   rpm:
     runs-on: ubuntu-latest
+    if: github.event.inputs.package_types == 'all' || github.event.inputs.package_types == 'rpm'
     container: rockylinux:latest
     strategy:
       fail-fast: false
@@ -217,6 +229,7 @@ jobs:
 
   homebrew:
     runs-on: macos-latest
+    if: github.event.inputs.package_types == 'all' || github.event.inputs.package_types == 'homebrew'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -35,7 +35,6 @@ env:
   DEVOPS_PRIVATE_KEY: ${{ secrets.DEVOPS_PRIVATE_KEY }}
   BINTRAY_PASSPHRASE: ${{ secrets.BINTRAY_PASSPHRASE }}
   HZ_LICENSEKEY: ${{ secrets.HZ_LICENSEKEY }}
-  PACKAGE_TYPES: ${{ github.event.inputs.package_types || 'all' }}
 
 # Constant for now - should ensure single build, maybe we can limit this to something from github.*
 concurrency: single-build
@@ -51,6 +50,7 @@ jobs:
     outputs:
       hz_version: ${{ steps.hz_version.outputs.hz_version }}
       package_version: ${{ steps.package_version.outputs.package_version }}
+      package_types: ${{ github.event.inputs.package_types || 'all' }}
     steps:
       - name: Checkout hazelcast-packaging repo
         uses: actions/checkout@v2.3.2
@@ -87,7 +87,7 @@ jobs:
 
   deb:
     runs-on: ubuntu-latest
-    if: ${{ env.PACKAGE_TYPES == 'all' || env.PACKAGE_TYPES == 'deb' }}
+    if: ${{ needs.prepare.outputs.package_types == 'all' || needs.prepare.outputs.package_types == 'deb' }}
     strategy:
       fail-fast: false
       matrix:
@@ -155,7 +155,7 @@ jobs:
 
   rpm:
     runs-on: ubuntu-latest
-    if: ${{ env.PACKAGE_TYPES == 'all' || env.PACKAGE_TYPES == 'rpm' }}
+    if: ${{ needs.prepare.outputs.package_types == 'all' || needs.prepare.outputs.package_types == 'rpm' }}
     container: rockylinux:latest
     strategy:
       fail-fast: false
@@ -230,7 +230,7 @@ jobs:
 
   homebrew:
     runs-on: macos-latest
-    if: ${{ env.PACKAGE_TYPES == 'all' || env.PACKAGE_TYPES == 'homebrew' }}
+    if: ${{ needs.prepare.outputs.package_types == 'all' || needs.prepare.outputs.package_types == 'homebrew' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -17,7 +17,7 @@ on:
       HZ_VERSION:
         description: 'Version of Hazelcast to build the image for, this is the Maven version - e.g.: 5.0.2 or 5.1-SNAPSHOT'
         required: true
-      package_types:
+      PACKAGE_TYPES:
         description: 'Packages to build'
         required: true
         default: 'all'
@@ -35,6 +35,7 @@ env:
   DEVOPS_PRIVATE_KEY: ${{ secrets.DEVOPS_PRIVATE_KEY }}
   BINTRAY_PASSPHRASE: ${{ secrets.BINTRAY_PASSPHRASE }}
   HZ_LICENSEKEY: ${{ secrets.HZ_LICENSEKEY }}
+  PACKAGE_TYPES: ${{ github.event.inputs.package_types || 'all' }}
 
 # Constant for now - should ensure single build, maybe we can limit this to something from github.*
 concurrency: single-build
@@ -86,7 +87,7 @@ jobs:
 
   deb:
     runs-on: ubuntu-latest
-    if: github.event.inputs.package_types == 'all' || github.event.inputs.package_types == 'deb'
+    if: env.PACKAGE_TYPES == 'all' || env.PACKAGE_TYPES == 'deb'
     strategy:
       fail-fast: false
       matrix:
@@ -154,7 +155,7 @@ jobs:
 
   rpm:
     runs-on: ubuntu-latest
-    if: github.event.inputs.package_types == 'all' || github.event.inputs.package_types == 'rpm'
+    if: env.PACKAGE_TYPES == 'all' || env.PACKAGE_TYPES == 'rpm'
     container: rockylinux:latest
     strategy:
       fail-fast: false
@@ -229,7 +230,7 @@ jobs:
 
   homebrew:
     runs-on: macos-latest
-    if: github.event.inputs.package_types == 'all' || github.event.inputs.package_types == 'homebrew'
+    if: env.PACKAGE_TYPES == 'all' || env.PACKAGE_TYPES == 'homebrew'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
A manually triggered workflow can be now limited to a single type of packaging system

<img width="434" alt="image" src="https://user-images.githubusercontent.com/1242724/156651582-264c8710-52c9-4f8d-9581-267f27ec0dbe.png">

Example run: https://github.com/hazelcast/hazelcast-packaging/actions/runs/1928601220

<img width="868" alt="image" src="https://user-images.githubusercontent.com/1242724/156650902-9352073e-b2f8-410b-9079-b0c4c9a5e34e.png">
