### PR TITLE
Do not allow installation of multiple hazelcast brew packages

### DIFF
--- a/build-hazelcast-homebrew-package.sh
+++ b/build-hazelcast-homebrew-package.sh
@@ -39,12 +39,6 @@ echo "Building Homebrew package $HZ_DISTRIBUTION:${HZ_VERSION} package version $
 
 ASSET_SHASUM=$(sha256sum "${HZ_DISTRIBUTION_FILE}" | cut -d ' ' -f 1)
 
-# If this is 'hazelcast' package it conflicts with 'hazelcast-enterprise' and vice versa
-export CONFLICTS=hazelcast-enterprise
-if [ ${HZ_DISTRIBUTION} == "hazelcast-enterprise" ]; then
-  export CONFLICTS=hazelcast
-fi
-
 TEMPLATE_FILE="$(pwd)/packages/brew/hazelcast-template.rb"
 cd ../homebrew-hz || exit 1
 
@@ -62,7 +56,13 @@ function generateFormula {
   updateClassName "$class" "$file"
   sed -i "s+url.*$+url \"${HZ_PACKAGE_URL}\"+g" "$file"
   sed -i "s+sha256.*$+sha256 \"${ASSET_SHASUM}\"+g" "$file"
-  sed -i "s+conflicts_with \".*\"$+conflicts_with \"$CONFLICTS\"+g" "$file"
+  all_hz_versions=(hazelcast*\.rb)
+  for version in "${all_hz_versions[@]}"
+  do
+    if [[ "$version" != "$file" ]]; then
+      sed -i "/sha256.*$/a \ \ \ \ conflicts_with \"${version%.rb}\", because: \"you can install only a single hazelcast or hazelcast-enterprise package\"" "$file"
+    fi
+  done
 }
 
 BREW_CLASS=$(brewClass "${HZ_DISTRIBUTION}" "${BREW_PACKAGE_VERSION}")

--- a/packages/brew/hazelcast-template.rb
+++ b/packages/brew/hazelcast-template.rb
@@ -3,8 +3,7 @@ class HazelcastAT5X < Formula
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://github.com/hazelcast/hazelcast-command-line/releases/download/v5.2021.07.1/hazelcast-5.0-BETA-1.tar.gz"
     sha256 "f108d22a1aec61bbd637f89ff522af7d9861ef13afcfad24a5095127f04f091d"
-    conflicts_with "hazelcast-enterprise", because: "You can install either hazelcast (open source under Apache 2) or hazelcast-enterprise (under Hazelcast license)"
-  
+
     depends_on "openjdk" => :recommended
 
     def install


### PR DESCRIPTION
Brew doesn't recognize the relation between versioned formulas, so it is possible to install multiple HZ packages but only the last one will be available on PATH which could be confusing for the users.

This PR provides additional conflict entries to forbid the installation of multiple HZ packages.

You can bypass it and have multiple HZ installations by running `brew unlink <old-package>`. 

Be aware that commands available on PATH will point to the last installation

A formula example:
```ruby
class Hazelcast < Formula
    desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
    homepage "https://github.com/hazelcast/hazelcast-command-line"
    url "https://repo.maven.apache.org/maven2/com/hazelcast/hazelcast-distribution/5.1/hazelcast-distribution-5.1.tar.gz"
    sha256 "8af0e906d1d33a8891660bd6233e91d55850b66a84313927f95056db202bace3"
    conflicts_with "hazelcast@5.2.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
    conflicts_with "hazelcast@5.1.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
    conflicts_with "hazelcast@5.1", because: "you can install only a single hazelcast or hazelcast-enterprise package"
    conflicts_with "hazelcast@5.1.dr6", because: "you can install only a single hazelcast or hazelcast-enterprise package"
    conflicts_with "hazelcast@5.1.beta.1", because: "you can install only a single hazelcast or hazelcast-enterprise package"
    conflicts_with "hazelcast@5.0", because: "you can install only a single hazelcast or hazelcast-enterprise package"
    conflicts_with "hazelcast@5.0.2", because: "you can install only a single hazelcast or hazelcast-enterprise package"
    conflicts_with "hazelcast@5.0.1", because: "you can install only a single hazelcast or hazelcast-enterprise package"
    ...
```

`brew info hazelcast` output:
```
 brew info hazelcast
hazelcast: stable 5.1
Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.
https://github.com/hazelcast/hazelcast-command-line
Conflicts with:
  hazelcast-5.0 (because you can install only a single hazelcast or hazelcast-enterprise package)
  hazelcast-5.1 (because you can install only a single hazelcast or hazelcast-enterprise package)
  hazelcast-enterprise (because you can install only a single hazelcast or hazelcast-enterprise package)
  hazelcast-enterprise-5.0 (because you can install only a single hazelcast or hazelcast-enterprise package)
  hazelcast-enterprise-5.1 (because you can install only a single hazelcast or hazelcast-enterprise package)
  hazelcast-enterprise@5.0 (because you can install only a single hazelcast or hazelcast-enterprise package)
  hazelcast-enterprise@5.0.1 (because you can install only a single hazelcast or hazelcast-enterprise package)
  hazelcast-enterprise@5.0.2 (because you can install only a single hazelcast or hazelcast-enterprise package)
  hazelcast-enterprise@5.1 (because you can install only a single hazelcast or hazelcast-enterprise package)
  ....
  ```

The error message from the installation of the conflicting package:
```
Error: Cannot install hazelcast@5.1 because conflicting formulae are installed.
  hazelcast-5.1: because you can install only a single hazelcast or hazelcast-enterprise package

Please `brew unlink hazelcast-5.1` before continuing.

Unlinking removes a formula's symlinks from /usr/local. You can
link the formula again after the install finishes. You can --force this
install, but the build may fail or cause obscure side effects in the
resulting software.
```
  