### PR TITLE
Use project.version expression to get version from pom.xml

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -56,7 +56,7 @@ jobs:
         id: hz_version
         run: |
           if [ -z "${{ env.HZ_VERSION }}" ]; then
-            HZ_VERSION=$(mvn help:evaluate -Dexpression=hazelcast.version -q -DforceStdout)
+            HZ_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           fi
           echo "HZ_VERSION=$HZ_VERSION" >> $GITHUB_ENV
           echo ::set-output name=hz_version::$HZ_VERSION

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <hazelcast.version>5.2-SNAPSHOT</hazelcast.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This way we can remove the property and the version needs to be updated
in single place only, which is less errorprone and easier to script in
Hazelcast release pipeline.