### PR TITLE
Use headless Java as dependency for deb and rpm packages

### DIFF
--- a/packages/deb/hazelcast/DEBIAN/control
+++ b/packages/deb/hazelcast/DEBIAN/control
@@ -5,7 +5,7 @@ Section: imdg
 Priority: optional
 Architecture: all
 Conflicts: ${CONFLICTS}
-Depends: default-jdk | java8-sdk
+Depends: default-jdk-headless | java8-sdk-headless
 Maintainer: Hazelcast Platform Team <platform@hazelcast.com>
 Description: A tool that allows users to install & run Hazelcast
 Homepage: https://www.hazelcast.com/

--- a/packages/rpm/hazelcast.spec
+++ b/packages/rpm/hazelcast.spec
@@ -18,7 +18,7 @@ Source1:    hazelcast.service
 
 Requires(pre): shadow-utils
 
-Requires:	java
+Requires:	java-headless
 
 BuildArch:  noarch
 BuildRequires: systemd-rpm-macros


### PR DESCRIPTION
This will save users time to download and some space locally.

I have check distribution packages in Ubuntu and RHEL and commonly
available Java packages from:

- Adoptopendk
- Temurin
- Oracle

and they all provide the correct meta package (deb) or capability (rpm).