### PR TITLE
Make logs directory writable for all users.

### DIFF
--- a/packages/deb/hazelcast/DEBIAN/postinst
+++ b/packages/deb/hazelcast/DEBIAN/postinst
@@ -13,6 +13,8 @@ done
 groupadd -r hazelcast
 useradd -r -g hazelcast -d /usr/lib/hazelcast -s /sbin/nologin hazelcast
 chown -R hazelcast:hazelcast /usr/lib/hazelcast
+mkdir -p /usr/lib/hazelcast/logs
+chmod 777 /usr/lib/hazelcast/logs
 
 if command -v systemctl > /dev/null; then
   systemctl daemon-reload

--- a/packages/rpm/hazelcast.spec
+++ b/packages/rpm/hazelcast.spec
@@ -68,6 +68,8 @@ rm -rf $RPM_BUILD_ROOT
 
 %post
 chown -R hazelcast:hazelcast %{_prefix}/lib/hazelcast/
+mkdir -p %{_prefix}/lib/hazelcast/logs
+chmod 777 %{_prefix}/lib/hazelcast/logs
 %systemd_post %{name}.service
 printf "\n\nHazelcast is successfully installed to '%{_prefix}/lib/hazelcast/'\n"
 printf "\n\nUse 'hz start' or 'systemctl start hazelcast' to start the Hazelcast server\n"


### PR DESCRIPTION
This PR fixes issue when a user installs deb/rpm package and runs `hz` directly instead of the systemd service.

Slack discussion: https://hazelcast.slack.com/archives/C02JGKJD9NY/p1646838782410859