### PR TITLE
Fix check if github.ref is a tag

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -77,7 +77,7 @@ jobs:
         # If the ref is version (e.g. v5.0.1) tag then use it as package version,
         # otherwise use HZ_VERSION for package version (e.g 5.1-SNAPSHOT)
         run: |
-          if [[ "${{ github.ref }}" == "v"* ]]; then
+          if [[ "${{ github.ref }}" == "refs/tags/v"* ]]; then
             PACKAGE_VERSION=$(echo ${{ github.ref }} | cut -c 12-)
           else
             PACKAGE_VERSION=${{ env.HZ_VERSION }}


### PR DESCRIPTION
The ref is in the format `refs/tags/v5.1-1`, the check didn't work, we
always used the version from the pom.xml.