### PR TITLE
Unify packaging by migrating from DR suffix to DEVEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ Run the following to install e.g. version `5.0.1`:
 brew install hazelcast@5.0.1
 ```
 
-## Installing a SNAPSHOT/BETA/DR version
+## Installing a SNAPSHOT/DEVEL/BETA version
 
-### Install a SNAPSHOT/BETA/DR version with apt
+### Install a SNAPSHOT/DEVEL/BETA version with apt
 
-You need to replace `stable` with `snapshot`/`beta`/`devel` (for DR) in
+You need to replace `stable` with `snapshot`/`devel`/`beta` in
 the repository definition to use Hazelcast snapshots.
 
 Run the following to install the latest snapshot version:
@@ -106,9 +106,9 @@ echo "deb https://repository.hazelcast.com/debian snapshot main" | sudo tee -a /
 sudo apt update && sudo apt install hazelcast
 ```
 
-### Install a SNAPSHOT/BETA/DR version with yum
+### Install a SNAPSHOT/DEVEL/BETA version with yum
 
-You need to replace `stable` with `snapshot`/`beta`/`devel` (for DR) in 
+You need to replace `stable` with `snapshot`/`devel`/`beta` in 
 the repository definition to use Hazelcast snapshots.
 
 Run the following to install the latest snapshot version:
@@ -119,9 +119,9 @@ sudo mv hazelcast-rpm-snapshot.repo /etc/yum.repos.d/
 sudo yum install hazelcast
 ```
 
-### Install a SNAPSHOT/BETA/DR version with Homebrew
+### Install a SNAPSHOT/DEVEL/BETA version with Homebrew
 
-You need to add `snapshot`/`beta`/`dr` suffix to the package version when 
+You need to add `snapshot`/`devel`/`beta` suffix to the package version when 
 installing a snapshot.
 
 Run the following to install the latest `5.1-SNAPSHOT` version:

--- a/build-hazelcast-homebrew-package.sh
+++ b/build-hazelcast-homebrew-package.sh
@@ -59,7 +59,7 @@ function generateFormula {
   all_hz_versions=({hazelcast.rb,hazelcast-devel.rb,hazelcast-snapshot.rb,hazelcast?[0-9]*\.rb,hazelcast-enterprise*\.rb})
   for version in "${all_hz_versions[@]}"
   do
-    if [[ "$version" != "$file" ]] && [[ ! "$version" =~ .*(beta|dr).* ]] ; then
+    if [[ "$version" != "$file" ]] && [[ ! "$version" =~ .*(beta|devel).* ]] ; then
       sed -i "/sha256.*$/a \ \ \ \ conflicts_with \"${version%.rb}\", because: \"you can install only a single hazelcast or hazelcast-enterprise package\"" "$file"
     fi
   done
@@ -70,7 +70,7 @@ generateFormula "$BREW_CLASS" "${HZ_DISTRIBUTION}@${BREW_PACKAGE_VERSION}.rb"
 
 HZ_MINOR_VERSION=$(echo "${HZ_VERSION}" | cut -c -3)
 
-# Update hazelcast and hazelcast-x.y aliases only if the version is a stable release (not SNAPSHOT/DR/BETA)
+# Update hazelcast and hazelcast-x.y aliases only if the version is a stable release (not SNAPSHOT/DEVEL/BETA)
 if [[ "$RELEASE_TYPE" = "stable" ]]; then
     rm -f "Aliases/${HZ_DISTRIBUTION}-${HZ_MINOR_VERSION}" #migrate incrementally from symlinks to regular files
     BREW_CLASS=$(brewClass "${HZ_DISTRIBUTION}${HZ_MINOR_VERSION}")

--- a/common.sh
+++ b/common.sh
@@ -4,7 +4,7 @@ export RELEASE_TYPE=stable
 if [[ "$HZ_VERSION" == *"SNAPSHOT"* ]]; then
   export RELEASE_TYPE=snapshot
 fi
-if [[ "$HZ_VERSION" == *"DR"* ]]; then
+if [[ "$HZ_VERSION" == *"DEVEL"* ]]; then
   export RELEASE_TYPE=devel
 fi
 if [[ "$HZ_VERSION" == *"BETA"* ]]; then

--- a/packages/brew/test_brew_functions.sh
+++ b/packages/brew/test_brew_functions.sh
@@ -38,13 +38,13 @@ function assertAlphanumCamelCase {
 log_header "Tests for alphanumCamelCase"
 assertAlphanumCamelCase "5.2-SNAPSHOT" "52Snapshot"
 assertAlphanumCamelCase "5.2-BETA-1" "52Beta1"
-assertAlphanumCamelCase "5.1-DR8" "51Dr8"
+assertAlphanumCamelCase "5.1-DEVEL-8" "51Devel8"
 assertAlphanumCamelCase "5.2" "52"
 assertAlphanumCamelCase "5.2.1" "521"
 assertAlphanumCamelCase "" ""
 assertAlphanumCamelCase "snapshot" "Snapshot"
 assertAlphanumCamelCase "beta" "Beta"
-assertAlphanumCamelCase "dr" "Dr"
+assertAlphanumCamelCase "devel" "Devel"
 
 function assertBrewClass {
   local distribution=$1
@@ -57,6 +57,7 @@ function assertBrewClass {
 log_header "Tests for brewClass"
 assertBrewClass "hazelcast" "5.2-SNAPSHOT" "HazelcastAT52Snapshot"
 assertBrewClass "hazelcast-enterprise" "5.2-BETA-1" "HazelcastEnterpriseAT52Beta1"
+assertBrewClass "hazelcast" "5.2-DEVEL-3" "HazelcastAT52Devel3"
 assertBrewClass "hazelcast" "5.2" "HazelcastAT52"
 assertBrewClass "hazelcast" "" "Hazelcast"
 assertBrewClass "hazelcast-enterprise" "" "HazelcastEnterprise"

--- a/test_common.sh
+++ b/test_common.sh
@@ -38,7 +38,7 @@ function assertReleaseType {
 log_header "Tests for RELEASE_TYPE"
 assertReleaseType "5.2-SNAPSHOT" "snapshot"
 assertReleaseType "5.2-BETA-1" "beta"
-assertReleaseType "5.1-DR8" "devel"
+assertReleaseType "5.1-DEVEL-8" "devel"
 assertReleaseType "5.0" "stable"
 assertReleaseType "5.1" "stable"
 assertReleaseType "5.1.1" "stable"
@@ -59,6 +59,7 @@ assertPackageVersions "5.0.2"        "5.0.2-1"       "5.0.2-1"           "5.0.2-
 assertPackageVersions "5.1"          "5.1"           "5.1-1"             "5.1-1"
 assertPackageVersions "5.1"          "5.1-1"         "5.1-1"             "5.1-1"
 assertPackageVersions "5.1-SNAPSHOT" "5.1-SNAPSHOT"  "5.1-SNAPSHOT-1"    "5.1.SNAPSHOT-1"
+assertPackageVersions "5.1-DEVEL"    "5.1-DEVEL"     "5.1-DEVEL-1"       "5.1.DEVEL-1"
 assertPackageVersions "5.1-BETA-1"   "5.1-BETA-1"    "5.1-BETA-1-1"      "5.1.BETA.1-1"
 assertPackageVersions "5.1-BETA-1"   "5.1-BETA-1-2"  "5.1-BETA-1-2"      "5.1.BETA.1-2"
 


### PR DESCRIPTION
As agreed we're changing suffix for development releases from `DR` to `DEVEL` to use a consistent and unified naming across releases and repositories.