### PR TITLE
Do not remove symlinks explicitly in RPM postun [HZ-906]

### DIFF
--- a/packages/rpm/hazelcast.spec
+++ b/packages/rpm/hazelcast.spec
@@ -77,22 +77,8 @@ printf "\n\nUse 'hz start' or 'systemctl start hazelcast' to start the Hazelcast
 %preun
 %systemd_preun %{name}.service
 
-
 %postun
 %systemd_postun %{name}.service
-
-echo "Removing symlinks from %{_bindir}"
-
-for FILENAME
- in %{_prefix}/lib/hazelcast/bin/hz*; do
-  case "${FILENAME}" in
-    *bat)
-      ;;
-    *)
-      rm %{_bindir}/"$(basename "${FILENAME}")"
-      ;;
-  esac
-done
 
 %files
 # The LICENSE file contains Apache 2 license and is only present in OS


### PR DESCRIPTION
Symlinks are listed in %files section so they don't need to be removed explicitly.