### PR TITLE
Upload deb with minor version as deb.component [HZ-1006]

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ echo "deb https://repository.hazelcast.com/debian stable main" | sudo tee -a /et
 sudo apt update
 ```
 
+NOTE: If you want to stay on latest patch version for a particular minor 
+release you can replace `main` component with `x.y`, e.g. `5.1`. 
+
+```shell
+wget -qO - https://repository.hazelcast.com/api/gpg/key/public | sudo apt-key add -
+echo "deb https://repository.hazelcast.com/debian stable 5.1" | sudo tee -a /etc/apt/sources.list
+sudo apt update
+```
+
 Install Hazelcast (open source)
 ```shell
 sudo apt install hazelcast

--- a/build-hazelcast-deb-package.sh
+++ b/build-hazelcast-deb-package.sh
@@ -77,6 +77,6 @@ if [ "${PUBLISH}" == "true" ]; then
     -H "X-Checksum-Sha1: $DEB_SHA1SUM" -H "X-Checksum-MD5: $DEB_MD5SUM" \
     -T"$DEB_FILE" \
     -X PUT \
-    "$DEBIAN_REPO_BASE_URL/$DEB_FILE;deb.distribution=${PACKAGE_REPO};deb.component=main;deb.architecture=all"
+    "$DEBIAN_REPO_BASE_URL/$DEB_FILE;deb.distribution=${PACKAGE_REPO};deb.component=main;deb.component=${HZ_MINOR_VERSION};deb.architecture=all"
 
 fi

--- a/build-hazelcast-homebrew-package.sh
+++ b/build-hazelcast-homebrew-package.sh
@@ -68,8 +68,6 @@ function generateFormula {
 BREW_CLASS=$(brewClass "${HZ_DISTRIBUTION}" "${BREW_PACKAGE_VERSION}")
 generateFormula "$BREW_CLASS" "${HZ_DISTRIBUTION}@${BREW_PACKAGE_VERSION}.rb"
 
-HZ_MINOR_VERSION=$(echo "${HZ_VERSION}" | cut -c -3)
-
 # Update hazelcast and hazelcast-x.y aliases only if the version is a stable release (not SNAPSHOT/DEVEL/BETA)
 if [[ "$RELEASE_TYPE" = "stable" ]]; then
     rm -f "Aliases/${HZ_DISTRIBUTION}-${HZ_MINOR_VERSION}" #migrate incrementally from symlinks to regular files

--- a/common.sh
+++ b/common.sh
@@ -12,6 +12,11 @@ if [[ "$HZ_VERSION" == *"BETA"* ]]; then
 fi
 export PACKAGE_REPO=$RELEASE_TYPE
 
+# Extract minor version from HZ_VERSION, works also for 5.10 etc..
+# -d'.' splits by delimiter, -f selects first two components
+HZ_MINOR_VERSION=$(echo "${HZ_VERSION}" | cut -f1,2 -d'.')
+export HZ_MINOR_VERSION
+
 # Extract release version from package version - release version is the version part specific to the package
 
 # Remove HZ_VERSION prefix from PACKAGE_VERSION,

--- a/test_common.sh
+++ b/test_common.sh
@@ -63,4 +63,18 @@ assertPackageVersions "5.1-DEVEL"    "5.1-DEVEL"     "5.1-DEVEL-1"       "5.1.DE
 assertPackageVersions "5.1-BETA-1"   "5.1-BETA-1"    "5.1-BETA-1-1"      "5.1.BETA.1-1"
 assertPackageVersions "5.1-BETA-1"   "5.1-BETA-1-2"  "5.1-BETA-1-2"      "5.1.BETA.1-2"
 
+function assertMinorVersion {
+  export HZ_VERSION=$1
+  local expected=$2
+  . "$SCRIPT_DIR"/common.sh
+  assert_eq "$expected" "$HZ_MINOR_VERSION" "Version $HZ_VERSION should be mapped to $HZ_MINOR_VERSION minor version" || TESTS_RESULT=$?
+}
+
+log_header "Tests for HZ_MINOR_VERSION"
+assertMinorVersion "5.2-SNAPSHOT" "5.2-SNAPSHOT"
+assertMinorVersion "5.10" "5.10"
+assertMinorVersion "5.10.1" "5.10"
+assertMinorVersion "5.0" "5.0"
+assertMinorVersion "5.1.1" "5.1"
+
 assert_eq 0 "$TESTS_RESULT" "All tests should pass"


### PR DESCRIPTION
This allows to install deb minor version easily and also provides an
easy way to upgrade to the latest patch version of a particular minor version.