### PR TITLE
Fix upgrades after versioning change by adding epoch field

### DIFF
--- a/packages/deb/hazelcast/DEBIAN/control
+++ b/packages/deb/hazelcast/DEBIAN/control
@@ -1,6 +1,6 @@
 Package: ${HZ_DISTRIBUTION}
 Source: hazelcast
-Version: ${PACKAGE_VERSION}
+Version: 1:${PACKAGE_VERSION}
 Section: imdg
 Priority: optional
 Architecture: all


### PR DESCRIPTION
This PR adds an epoch field to overcome upgrades not working after the versioning scheme change from `5.2021.12.1` to `5.1`

Tested installation locally:
```
root@0d10b8a0c74b:/build# dpkg -i hazelcast-5.1-1-all.deb
Selecting previously unselected package hazelcast.
(Reading database ... 7966 files and directories currently installed.)
Preparing to unpack hazelcast-5.1-1-all.deb ...
Unpacking hazelcast (1:5.1) ...
Setting up hazelcast (1:5.1) ...
groupadd: group 'hazelcast' already exists
useradd: user 'hazelcast' already exists

Hazelcast is successfully installed to '/usr/lib/hazelcast/'
```