### PR TITLE
Do not change owner of the logs during upgrades

### DIFF
--- a/packages/deb/hazelcast/DEBIAN/postinst
+++ b/packages/deb/hazelcast/DEBIAN/postinst
@@ -12,7 +12,7 @@ done
 
 groupadd -r hazelcast
 useradd -r -g hazelcast -d /usr/lib/hazelcast -s /sbin/nologin hazelcast
-chown -R hazelcast:hazelcast /usr/lib/hazelcast
+find /usr/lib/hazelcast -not -path "*/logs/*" -exec chown hazelcast:hazelcast {} \;
 mkdir -p /usr/lib/hazelcast/logs
 chmod 777 /usr/lib/hazelcast/logs
 

--- a/packages/rpm/hazelcast.spec
+++ b/packages/rpm/hazelcast.spec
@@ -67,7 +67,7 @@ echo 'hazelcastDownloadId=rpm' > "%{buildroot}%{_prefix}/lib/hazelcast/lib/hazel
 rm -rf $RPM_BUILD_ROOT
 
 %post
-chown -R hazelcast:hazelcast %{_prefix}/lib/hazelcast/
+find %{_prefix}/lib/hazelcast -not -path "*/logs/*" -exec chown hazelcast:hazelcast {} \;
 mkdir -p %{_prefix}/lib/hazelcast/logs
 chmod 777 %{_prefix}/lib/hazelcast/logs
 %systemd_post %{name}.service


### PR DESCRIPTION
Currently, when users install HZ from deb or rpm we change the owners of all log files to the `hazelcast` user. 

This can result in permission errors for users starting HZ with `hz start` command.

This PR excludes contents of `logs` directory from setting up ownership during installation/upgrade 

### Testing
- Installed the current stable version from rpm/deb repositories. 
- Started the instance with `hz start` and then stopped it
- Confirmed that /usr/lib/hazelcast/logs/hazelcast.log is owned by the current user
- Build deb/rpm packages from this PR and installed them locally
- Confirmed that /usr/lib/hazelcast/logs/hazelcast.log is still owned by the current user and not `hazelcast`