### PR TITLE
Describe how to install repository keys on Ubuntu without deprecated apt-key

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -131,8 +131,8 @@ jobs:
       - name: Install Hazelcast from deb
         run: |
           source ./common.sh
-          wget -qO - https://repository.hazelcast.com/api/gpg/key/public | sudo apt-key add -
-          echo "deb ${DEBIAN_REPO_BASE_URL} ${PACKAGE_REPO} main" | sudo tee -a /etc/apt/sources.list
+          wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] ${DEBIAN_REPO_BASE_URL} ${PACKAGE_REPO} main" | sudo tee -a /etc/apt/sources.list
           sudo apt update && sudo apt install ${{ env.HZ_DISTRIBUTION}}=${HZ_VERSION}
           HAZELCAST_CONFIG="$(pwd)/config/integration-test-hazelcast.yaml" hz-start > hz.log 2>&1 &
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Run the following commands to install the package using apt:
 
 Add repository
 ```shell
-wget -qO - https://repository.hazelcast.com/api/gpg/key/public | sudo apt-key add -
-echo "deb https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
+wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
 sudo apt update
 ```
 
@@ -32,8 +32,8 @@ NOTE: If you want to stay on latest patch version for a particular minor
 release you can replace `main` component with `x.y`, e.g. `5.1`. 
 
 ```shell
-wget -qO - https://repository.hazelcast.com/api/gpg/key/public | sudo apt-key add -
-echo "deb https://repository.hazelcast.com/debian stable 5.1" | sudo tee -a /etc/apt/sources.list
+wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian stable 5.1" | sudo tee -a /etc/apt/sources.list
 sudo apt update
 ```
 
@@ -177,8 +177,8 @@ Run the following to install the latest snapshot version:
 
 Add repository
 ```shell
-wget -qO - https://repository.hazelcast.com/api/gpg/key/public | sudo apt-key add -
-echo "deb https://repository.hazelcast.com/debian snapshot main" | sudo tee -a /etc/apt/sources.list
+wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian snapshot main" | sudo tee -a /etc/apt/sources.list
 sudo apt update
 ```
 


### PR DESCRIPTION
Ubuntu 22.04 complains about `apt-key` being deprecated as an insecure method of adding signing keys.

This PR changes the description and CI tests to use the currently preferred method of adding keys of 3rd party repositories. 

I've tested the method against all LTS Ubuntus starting from 16.04.

More information: https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html

Related docs PR: https://github.com/hazelcast/hz-docs/pull/425