### PR TITLE
Install gettext package for envsubst tool

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -183,7 +183,7 @@ jobs:
 
       - name: Install Required tools
         run: |
-          yum install -y maven rpm-sign rpm-build wget
+          yum install -y maven rpm-sign rpm-build wget gettext
 
       - name: Download the distribution tar.gz file
         run: |


### PR DESCRIPTION
Previously we installed this package as a transitive dependency of one of

maven 
rpm-sign 
rpm-build 
wget

It doesn't seem to be the case anymore.
Anyway, it is best to declare it directly because we use it.
