### PR TITLE
Replace deprecated set-output with GITHUB_OUTPUT [5.1.z]

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -70,7 +70,7 @@ jobs:
             HZ_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           fi
           echo "HZ_VERSION=$HZ_VERSION" >> $GITHUB_ENV
-          echo ::set-output name=hz_version::$HZ_VERSION
+          echo "hz_version=$HZ_VERSION" >> $GITHUB_OUTPUT
 
       - name: Set PACKAGE_VERSION
         id: package_version
@@ -83,7 +83,7 @@ jobs:
             PACKAGE_VERSION=${{ env.HZ_VERSION }}
           fi
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
-          echo ::set-output name=package_version::$PACKAGE_VERSION
+          echo "package_version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
 
   deb:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-packaging/pull/164

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/