### PR TITLE
Fix deb and rpm publishing [5.2.z]

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -31,7 +31,7 @@ on:
 env:
   EVENT_NAME: ${{ github.event_name }}
   PUBLISH: "true"
-  ARTIFACTORY_SECRET: ${{ secrets.ARTIFACTORY_SECRET }}
+  JFROG_TOKEN: ${{ secrets.JFROG_TOKEN }}
   DEVOPS_PRIVATE_KEY: ${{ secrets.DEVOPS_PRIVATE_KEY }}
   BINTRAY_PASSPHRASE: ${{ secrets.BINTRAY_PASSPHRASE }}
   HZ_LICENSEKEY: ${{ secrets.HZ_LICENSEKEY }}
@@ -125,7 +125,7 @@ jobs:
         run: |
           source common.sh
 
-          curl -H "Authorization: Bearer ${{ secrets.ARTIFACTORY_SECRET }}" \
+          curl -H "Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" \
             -X POST "https://repository.hazelcast.com/api/deb/reindex/${DEBIAN_REPO}"
 
       - name: Install Hazelcast from deb
@@ -149,7 +149,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           source ./common.sh
-          curl -H "Authorization: Bearer ${{ secrets.ARTIFACTORY_SECRET }}" \
+          curl -H "Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" \
             -X DELETE \
             "$DEBIAN_REPO_BASE_URL/${HZ_DISTRIBUTION}-${DEB_PACKAGE_VERSION}-all.deb"
 
@@ -183,7 +183,7 @@ jobs:
 
       - name: Install Required tools
         run: |
-          yum install -y maven rpm-sign rpm-build wget gettext
+          yum install -y maven rpm-sign rpm-build wget gettext systemd-rpm-macros
 
       - name: Download the distribution tar.gz file
         run: |
@@ -200,7 +200,7 @@ jobs:
           ls -lah
           source ./common.sh
 
-          curl -H "Authorization: Bearer ${{ secrets.ARTIFACTORY_SECRET }}" \
+          curl -H "Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" \
             -X POST "https://repository.hazelcast.com/api/yum/${RPM_REPO}"
 
       - name: Install Hazelcast from rpm
@@ -224,7 +224,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           source ./common.sh
-          curl -H "Authorization: Bearer ${{ secrets.ARTIFACTORY_SECRET }}" \
+          curl -H "Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" \
             -X DELETE \
             "$RPM_REPO_BASE_URL/${PACKAGE_REPO}/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm"
 

--- a/build-hazelcast-deb-package.sh
+++ b/build-hazelcast-deb-package.sh
@@ -69,11 +69,11 @@ if [ "${PUBLISH}" == "true" ]; then
   DEB_MD5SUM=$(md5sum $DEB_FILE | cut -d ' ' -f 1)
 
   # Delete any package that exists - previous version of the same package
-  curl -H "Authorization: Bearer ${ARTIFACTORY_SECRET}" \
+  curl -H "Authorization: Bearer ${JFROG_TOKEN}" \
     -X DELETE \
     "$DEBIAN_REPO_BASE_URL/${DEB_FILE}"
 
-  curl -H "Authorization: Bearer ${ARTIFACTORY_SECRET}" -H "X-Checksum-Deploy: false" -H "X-Checksum-Sha256: $DEB_SHA256SUM" \
+  curl -H "Authorization: Bearer ${JFROG_TOKEN}" -H "X-Checksum-Deploy: false" -H "X-Checksum-Sha256: $DEB_SHA256SUM" \
     -H "X-Checksum-Sha1: $DEB_SHA1SUM" -H "X-Checksum-MD5: $DEB_MD5SUM" \
     -T"$DEB_FILE" \
     -X PUT \

--- a/build-hazelcast-rpm-package.sh
+++ b/build-hazelcast-rpm-package.sh
@@ -69,11 +69,11 @@ if [ "${PUBLISH}" == "true" ]; then
   RPM_MD5SUM=$(md5sum "build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm" | cut -d ' ' -f 1)
 
   # Delete any package that exists - previous version of the same package
-  curl -H "Authorization: Bearer ${ARTIFACTORY_SECRET}" \
+  curl -H "Authorization: Bearer ${JFROG_TOKEN}" \
     -X DELETE \
     "$RPM_REPO_BASE_URL/${PACKAGE_REPO}/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm"
 
-  curl -H "Authorization: Bearer ${ARTIFACTORY_SECRET}" -H "X-Checksum-Deploy: false" -H "X-Checksum-Sha256: $RPM_SHA256SUM" \
+  curl -H "Authorization: Bearer ${JFROG_TOKEN}" -H "X-Checksum-Deploy: false" -H "X-Checksum-Sha256: $RPM_SHA256SUM" \
     -H "X-Checksum-Sha1: $RPM_SHA1SUM" -H "X-Checksum-MD5: $RPM_MD5SUM" \
     -T"build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm" \
     -X PUT \

--- a/repos/README.md
+++ b/repos/README.md
@@ -7,6 +7,6 @@ structure).
 Upload the file to artifactory:
 
 ```
-curl -H "Authorization: Bearer ${ARTIFACTORY_SECRET}" -Thazelcast-rpm-stable.repo -X PUT "https://repository.hazelcast.com/rpm-local/stable/"
+curl -H "Authorization: Bearer ${JFROG_TOKEN}" -Thazelcast-rpm-stable.repo -X PUT "https://repository.hazelcast.com/rpm-local/stable/"
 ```
 


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-packaging/pull/155

- Added missing runtime dependency for rpm-build
- Use JFROG_TOKEN instead of revoked ARTIFACTORY_TOKEN