### PR TITLE
Fix getting distribution url when publishing [5.3.0]

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -62,7 +62,6 @@ jobs:
         with:
           java-version: '8'
           distribution: 'temurin'
-          cache: 'maven'
 
       - name: Set HZ_VERSION
         id: hz_version
@@ -112,7 +111,6 @@ jobs:
         with:
           java-version: '8'
           distribution: 'temurin'
-          cache: 'maven'
 
       - name: Download the distribution tar.gz file
         run: |


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-packaging/pull/170

We need to disable cache to get url from mvn