### PR TITLE
Retry index recalculation and fail runs on error [5.3.z]

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           source common.sh
 
-          curl -H "Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" \
+          curl --fail-with-body --retry 3 --retry-delay 10 -H "Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" \
             -X POST "https://repository.hazelcast.com/api/deb/reindex/${DEBIAN_REPO}"
 
       - name: Install Hazelcast from deb
@@ -200,7 +200,7 @@ jobs:
           ls -lah
           source ./common.sh
 
-          curl -H "Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" \
+          curl --fail-with-body --retry 3 --retry-delay 10 -H "Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" \
             -X POST "https://repository.hazelcast.com/api/yum/${RPM_REPO}"
 
       - name: Install Hazelcast from rpm


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-packaging/pull/176

Recalculation of Debian and RPM repository metadata can take some time which can lead to timeouts. This PR adds retrying and also makes sure we fail the workflow run if the recalculation request has failed.

Internal discussion: https://hazelcast.slack.com/archives/C03UE7ERB0V/p1684483313536939?thread_ts=1684482073.154759&cid=C03UE7ERB0V