### PR TITLE
Update 5.3.z SNAPSHOT version to 5.3.6 [5.3.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-packaging</artifactId>
-    <version>5.3.4-SNAPSHOT</version>
+    <version>5.3.6-SNAPSHOT</version>
 
     <description>A pom.xml file with repository definitions so we can use maven to fetch tar artifacts.</description>
 


### PR DESCRIPTION
We have skipped 5.3.3 and 5.3.4 and released 5.3.5 instead. This change will ensure next release (5.3.6) is properly created from 5.3.z

Fixes: [HZ-3546]

[HZ-3546]: https://hazelcast.atlassian.net/browse/HZ-3546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ