### PR TITLE
Make custom-lib optional and switch to JDK 11 [5.3.z]

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'temurin'
 
       - name: Set HZ_VERSION
@@ -109,7 +109,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'temurin'
 
       - name: Download the distribution tar.gz file
@@ -178,7 +178,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'temurin'
 
       - name: Install Required tools
@@ -267,7 +267,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'temurin'
 
       - name: Download the distribution tar.gz file

--- a/packages/rpm/hazelcast.spec
+++ b/packages/rpm/hazelcast.spec
@@ -60,6 +60,8 @@ rm -rf $RPM_BUILD_ROOT
 %{__ln_s} %{_prefix}/lib/hazelcast/bin/hz-healthcheck %{buildroot}%{_bindir}/hz-healthcheck
 %{__ln_s} %{_prefix}/lib/hazelcast/bin/hz-start %{buildroot}%{_bindir}/hz-start
 %{__ln_s} %{_prefix}/lib/hazelcast/bin/hz-stop %{buildroot}%{_bindir}/hz-stop
+# Fix for missing custom-lib
+%{__mkdir} -p %{buildroot}%{_prefix}/lib/hazelcast/custom-lib
 
 echo 'hazelcastDownloadId=rpm' > "%{buildroot}%{_prefix}/lib/hazelcast/lib/hazelcast-download.properties"
 


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-packaging/pull/187

- Currently `custom-lib` is not present in the distribution
- Switch to JDK 11 in tests: Starting from 5.4.0 we require JDK 11