### PR TITLE
Upgrade runtime images to Java 21 [HZ-4198]

### DIFF
--- a/packages/brew/hazelcast-template.rb
+++ b/packages/brew/hazelcast-template.rb
@@ -4,7 +4,7 @@ class HazelcastAT5X < Formula
     url "https://github.com/hazelcast/hazelcast-command-line/releases/download/v5.2021.07.1/hazelcast-5.0-BETA-1.tar.gz"
     sha256 "f108d22a1aec61bbd637f89ff522af7d9861ef13afcfad24a5095127f04f091d"
 
-    depends_on "openjdk" => :recommended
+    depends_on "openjdk@21" => :recommended
 
     def install
       libexec.install Dir["*"]

--- a/packages/deb/hazelcast/DEBIAN/control
+++ b/packages/deb/hazelcast/DEBIAN/control
@@ -5,7 +5,7 @@ Section: imdg
 Priority: optional
 Architecture: all
 Conflicts: ${CONFLICTS}
-Depends: default-jdk-headless | java21-sdk-headless
+Depends: java21-sdk-headless
 Maintainer: Hazelcast Platform Team <platform@hazelcast.com>
 Description: A tool that allows users to install & run Hazelcast
 Homepage: https://www.hazelcast.com/

--- a/packages/deb/hazelcast/DEBIAN/control
+++ b/packages/deb/hazelcast/DEBIAN/control
@@ -5,7 +5,7 @@ Section: imdg
 Priority: optional
 Architecture: all
 Conflicts: ${CONFLICTS}
-Depends: default-jdk-headless | java8-sdk-headless
+Depends: default-jdk-headless | java21-sdk-headless
 Maintainer: Hazelcast Platform Team <platform@hazelcast.com>
 Description: A tool that allows users to install & run Hazelcast
 Homepage: https://www.hazelcast.com/

--- a/packages/rpm/hazelcast.spec
+++ b/packages/rpm/hazelcast.spec
@@ -18,7 +18,7 @@ Source1:    hazelcast.service
 
 Requires(pre): shadow-utils
 
-Requires:	java-headless
+Requires:	java-21
 
 BuildArch:  noarch
 BuildRequires: systemd-rpm-macros


### PR DESCRIPTION
Hazelcast runtime images should use the latest supported Java runtime, which is currently Java 21. This change has already been made in https://github.com/hazelcast/hazelcast-docker/pull/717.

|        	| Was                                                                                                                                                                                                                                                                                                                     	| Now                                                                                                                    	|
|--------	|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|------------------------------------------------------------------------------------------------------------------------	|
| brew   	| Java 21 (implicitly)<br><br>verified in Docker using `brew install --build-from-source hazelcast-template.rb`                                                                                                                                                                                                           	| Java 21 (explicitly)                                                                                                   	|
| debian 	| Java 8 (explicitly)<br><br>Should already have been upgraded as Hazelcast 5.3 requires Java 11                                                                                                                                                                                                                          	| Java 21 (explicitly)                                                                                                   	|
| rpm    	| Was - Java 8 (implicitly)<br><br>verified in Docker (UBI 8.1) using `yum whatprovides java-headless`<br>`java-1.8.0-openjdk-1:1.8.0.402.b06-2.el8.aarch64 : OpenJDK 8 Runtime Environment`<br><br>java-headless is [no longer supported](https://unix.stackexchange.com/a/504715), hence the old version being resolved 	| Java 21 (explicitly)<br><br>resolves to `java-21-openjdk-1:21.0.2.0.13-1.el8.aarch64 : OpenJDK 21 Runtime Environment` 	|

Fixes [HZ-4198](https://hazelcast.atlassian.net/browse/HZ-4198)

[HZ-4198]: https://hazelcast.atlassian.net/browse/HZ-4198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ