### PR TITLE
Upgrade `publish-packages` action to use Java 21

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: $JAVA_VERSION
-          distribution: $JAVA_DISTRIBUTION
+          java-version: ${{ JAVA_VERSION }}
+          distribution: ${{ JAVA_DISTRIBUTION }}
 
       - name: Set HZ_VERSION
         id: hz_version
@@ -111,8 +111,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: $JAVA_VERSION
-          distribution: $JAVA_DISTRIBUTION
+          java-version: ${{ JAVA_VERSION }}
+          distribution: ${{ JAVA_DISTRIBUTION }}
 
       - name: Download the distribution tar.gz file
         run: |
@@ -180,8 +180,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: $JAVA_VERSION
-          distribution: $JAVA_DISTRIBUTION
+          java-version: ${{ JAVA_VERSION }}
+          distribution: ${{ JAVA_DISTRIBUTION }}
 
       - name: Install Required tools
         run: |
@@ -269,8 +269,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: $JAVA_VERSION
-          distribution: $JAVA_DISTRIBUTION
+          java-version: ${{ JAVA_VERSION }}
+          distribution: ${{ JAVA_DISTRIBUTION }}
 
       - name: Download the distribution tar.gz file
         run: |

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -35,6 +35,8 @@ env:
   DEVOPS_PRIVATE_KEY: ${{ secrets.DEVOPS_PRIVATE_KEY }}
   BINTRAY_PASSPHRASE: ${{ secrets.BINTRAY_PASSPHRASE }}
   HZ_LICENSEKEY: ${{ secrets.HZ_LICENSEKEY }}
+  JAVA_VERSION: "21"
+  JAVA_DISTRIBUTION: "temurin"
 
 # Constant for now - should ensure single build, maybe we can limit this to something from github.*
 concurrency: single-build
@@ -60,8 +62,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'temurin'
+          java-version: '$JAVA_VERSION'
+          distribution: '$JAVA_DISTRIBUTION'
 
       - name: Set HZ_VERSION
         id: hz_version
@@ -109,8 +111,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'temurin'
+          java-version: '$JAVA_VERSION'
+          distribution: '$JAVA_DISTRIBUTION'
 
       - name: Download the distribution tar.gz file
         run: |
@@ -178,8 +180,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'temurin'
+          java-version: '$JAVA_VERSION'
+          distribution: '$JAVA_DISTRIBUTION'
 
       - name: Install Required tools
         run: |
@@ -267,8 +269,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'temurin'
+          java-version: '$JAVA_VERSION'
+          distribution: '$JAVA_DISTRIBUTION'
 
       - name: Download the distribution tar.gz file
         run: |

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ JAVA_VERSION }}
-          distribution: ${{ JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Set HZ_VERSION
         id: hz_version
@@ -111,8 +111,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ JAVA_VERSION }}
-          distribution: ${{ JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Download the distribution tar.gz file
         run: |
@@ -180,8 +180,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ JAVA_VERSION }}
-          distribution: ${{ JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Install Required tools
         run: |
@@ -269,8 +269,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ JAVA_VERSION }}
-          distribution: ${{ JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Download the distribution tar.gz file
         run: |

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '$JAVA_VERSION'
-          distribution: '$JAVA_DISTRIBUTION'
+          java-version: $JAVA_VERSION
+          distribution: $JAVA_DISTRIBUTION
 
       - name: Set HZ_VERSION
         id: hz_version
@@ -111,8 +111,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '$JAVA_VERSION'
-          distribution: '$JAVA_DISTRIBUTION'
+          java-version: $JAVA_VERSION
+          distribution: $JAVA_DISTRIBUTION
 
       - name: Download the distribution tar.gz file
         run: |
@@ -180,8 +180,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '$JAVA_VERSION'
-          distribution: '$JAVA_DISTRIBUTION'
+          java-version: $JAVA_VERSION
+          distribution: $JAVA_DISTRIBUTION
 
       - name: Install Required tools
         run: |
@@ -269,8 +269,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '$JAVA_VERSION'
-          distribution: '$JAVA_DISTRIBUTION'
+          java-version: $JAVA_VERSION
+          distribution: $JAVA_DISTRIBUTION
 
       - name: Download the distribution tar.gz file
         run: |


### PR DESCRIPTION
The `.github/workflows/publish-packages.yml` uses Java 11 internally.

Java is only used to support Maven `dependency:copy` operations, so version does not need to be tied to Hazelcast supported versions, but it makes sense to be on the latest LTS release (21).

Centralised configuration - no need to externalise as only used in a single script.