### PR TITLE
Prepare 5.2.5 release branch from v5.2.4 [HZ-3723][5.2.5]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-packaging</artifactId>
-    <version>5.2.4</version>
+    <version>5.2.5-SNAPSHOT</version>
 
     <description>A pom.xml file with repository definitions so we can use maven to fetch tar artifacts.</description>
 


### PR DESCRIPTION
Changes to prepare for 5.2.5 release

- Branch was manually created from v5.2.4
- Updated POM version manually to 5.2.5-SNAPSHOT