### PR TITLE
Update POM version to 5.2.6-SNAPSHOT [HZ-3723][5.2.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-packaging</artifactId>
-    <version>5.2.5-SNAPSHOT</version>
+    <version>5.2.6-SNAPSHOT</version>
 
     <description>A pom.xml file with repository definitions so we can use maven to fetch tar artifacts.</description>
 


### PR DESCRIPTION
Update version in 5.2.z to 5.2.6-SNAPSHOT

Follow-up from https://github.com/hazelcast/hazelcast-packaging/pull/198

Fixes: [HZ-3723]

[HZ-3723]: https://hazelcast.atlassian.net/browse/HZ-3723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ