### PR TITLE
Update POM version to 5.3.8-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-packaging</artifactId>
-    <version>5.3.7-SNAPSHOT</version>
+    <version>5.3.8-SNAPSHOT</version>
 
     <description>A pom.xml file with repository definitions so we can use maven to fetch tar artifacts.</description>
 


### PR DESCRIPTION
Updating 5.3.z branch after Release 5.3.7 branch was created previously from v5.3.6

Fixes: [HZ-4188]

Backport of: https://github.com/hazelcast/hazelcast-packaging/pull/202