### PR TITLE
Use internal snapshot repository for OSS snapshot packages [DI-154] [5.5.z]

### DIFF
--- a/.github/workflows/build.functions.sh
+++ b/.github/workflows/build.functions.sh
@@ -32,3 +32,27 @@ function should_build_ee() {
   fi
 }
 
+function get_hz_dist_tar_gz() {
+  local hz_version=$1
+  local distribution=$2
+  local extension=tar.gz
+
+  if [[ $distribution == "hazelcast" ]]; then
+    if [[ "${hz_version}" == *"SNAPSHOT"* ]]; then
+      url="https://${HZ_SNAPSHOT_INTERNAL_USERNAME}:${HZ_SNAPSHOT_INTERNAL_PASSWORD}@repository.hazelcast.com/snapshot-internal/com/hazelcast/hazelcast-distribution/${hz_version}/hazelcast-distribution-${hz_version}.$extension"
+    else
+      url="https://repo1.maven.org/maven2/com/hazelcast/hazelcast-distribution/${hz_version}/hazelcast-distribution-${hz_version}.$extension"
+    fi
+  fi
+
+  if [[ $distribution == "hazelcast-enterprise" ]]; then
+    local repository
+    if [[ "${hz_version}" == *"SNAPSHOT"* ]]; then
+      repository=snapshot
+    else
+      repository=release
+    fi
+    url="https://repository.hazelcast.com/${repository}/com/hazelcast/hazelcast-enterprise-distribution/${hz_version}/hazelcast-enterprise-distribution-${hz_version}.$extension"
+  fi
+  echo "$url"
+}

--- a/.github/workflows/build.functions_tests.sh
+++ b/.github/workflows/build.functions_tests.sh
@@ -48,4 +48,21 @@ assert_should_build_ee "pull_request" "ALL" "yes"
 assert_should_build_ee "pull_request" "OSS" "yes"
 assert_should_build_ee "pull_request" "EE" "yes"
 
+function assert_get_hz_dist_tar_gz {
+  local hz_version=$1
+  local distribution=$2
+  local expected_url=$3
+  local actual_url=$(get_hz_dist_tar_gz "$hz_version" "$distribution")
+  assert_eq "$expected_url" "$actual_url" "Expected URL for version \"$hz_version\", distribution \"$distribution\"" || TESTS_RESULT=$?
+}
+
+log_header "Tests for get_hz_dist_tar_gz"
+export HZ_SNAPSHOT_INTERNAL_USERNAME=dummy_user
+export HZ_SNAPSHOT_INTERNAL_PASSWORD=dummy_password
+assert_get_hz_dist_tar_gz 5.4.0 hazelcast https://repo1.maven.org/maven2/com/hazelcast/hazelcast-distribution/5.4.0/hazelcast-distribution-5.4.0.tar.gz
+assert_get_hz_dist_tar_gz 5.5.0-SNAPSHOT hazelcast https://dummy_user:dummy_password@repository.hazelcast.com/snapshot-internal/com/hazelcast/hazelcast-distribution/5.5.0-SNAPSHOT/hazelcast-distribution-5.5.0-SNAPSHOT.tar.gz
+
+assert_get_hz_dist_tar_gz 5.4.0 hazelcast-enterprise https://repository.hazelcast.com/release/com/hazelcast/hazelcast-enterprise-distribution/5.4.0/hazelcast-enterprise-distribution-5.4.0.tar.gz
+assert_get_hz_dist_tar_gz 5.5.0-SNAPSHOT hazelcast-enterprise https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.5.0-SNAPSHOT/hazelcast-enterprise-distribution-5.5.0-SNAPSHOT.tar.gz
+
 assert_eq 0 "$TESTS_RESULT" "ALL tests should pass"

--- a/.github/workflows/publish-brew-package.yml
+++ b/.github/workflows/publish-brew-package.yml
@@ -56,9 +56,16 @@ jobs:
 
       - name: Download the distribution tar.gz file
         run: |
-          HZ_PACKAGE_URL=$(mvn --batch-mode dependency:copy -Dartifact=com.hazelcast:${HZ_DISTRIBUTION}-distribution:${HZ_VERSION}:tar.gz \
-          -DoutputDirectory=./ -Dmdep.useBaseVersion=true | grep 'Downloaded from' | grep -Eo "https://[^ >]+${HZ_DISTRIBUTION}-distribution-.*.tar.gz")
-          echo "HZ_PACKAGE_URL=$HZ_PACKAGE_URL" >> $GITHUB_ENV
+          . .github/workflows/build.functions.sh
+          export HZ_SNAPSHOT_INTERNAL_PASSWORD=${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
+          export HZ_SNAPSHOT_INTERNAL_USERNAME=${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
+          DISTRIBUTION_URL=$(get_hz_dist_tar_gz "${HZ_VERSION}" "${HZ_DISTRIBUTION}")
+          if [[ "DISTRIBUTION_URL" == *"$HZ_SNAPSHOT_INTERNAL_PASSWORD"* ]]; then
+             echo "Trying to expose a password-protected url of the distribution file, aborting!";
+             exit 1;
+          fi
+          curl --fail --silent --show-error --location "$DISTRIBUTION_URL" --output distribution.tar.gz 
+          echo "HZ_PACKAGE_URL=$DISTRIBUTION_URL" >> $GITHUB_ENV
 
       - name: Get homebrew repository
         run: |

--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -49,8 +49,11 @@ jobs:
 
       - name: Download the distribution tar.gz file
         run: |
-          mvn --batch-mode dependency:copy -Dartifact=com.hazelcast:${HZ_DISTRIBUTION}-distribution:${HZ_VERSION}:tar.gz \
-          -DoutputDirectory=./ -Dmdep.useBaseVersion=true
+          . .github/workflows/build.functions.sh
+          export HZ_SNAPSHOT_INTERNAL_PASSWORD=${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
+          export HZ_SNAPSHOT_INTERNAL_USERNAME=${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
+          DISTRIBUTION_URL=$(get_hz_dist_tar_gz "${HZ_VERSION}" "${HZ_DISTRIBUTION}")
+          curl --fail --silent --show-error --location "$DISTRIBUTION_URL" --output distribution.tar.gz 
 
       - name: Create & Upload DEB package
         run: |

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -157,7 +157,7 @@ jobs:
      USE_TEST_REPO: ${{ needs.prepare.outputs.use_test_repo }}
   brew-oss:
     needs: [ prepare ]
-    if: needs.prepare.outputs.should_build_homebrew == 'true' && needs.prepare.outputs.should_build_oss == 'yes'
+    if: needs.prepare.outputs.should_build_homebrew == 'true' && needs.prepare.outputs.should_build_oss == 'yes' && !contains(needs.prepare.outputs.hz_version, 'SNAPSHOT')
     uses: ./.github/workflows/publish-brew-package.yml
     secrets: inherit
     with:

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -55,8 +55,11 @@ jobs:
 
       - name: Download the distribution tar.gz file
         run: |
-          mvn --batch-mode dependency:copy -Dartifact=com.hazelcast:${HZ_DISTRIBUTION}-distribution:${HZ_VERSION}:tar.gz \
-          -DoutputDirectory=./ -Dmdep.useBaseVersion=true
+          . .github/workflows/build.functions.sh
+          export HZ_SNAPSHOT_INTERNAL_PASSWORD=${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
+          export HZ_SNAPSHOT_INTERNAL_USERNAME=${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
+          DISTRIBUTION_URL=$(get_hz_dist_tar_gz "${HZ_VERSION}" "${HZ_DISTRIBUTION}")
+          curl --fail --silent --show-error --location "$DISTRIBUTION_URL" --output distribution.tar.gz 
 
       - name: Create & Sign & Upload RPM package
         run: |

--- a/build-hazelcast-deb-package.sh
+++ b/build-hazelcast-deb-package.sh
@@ -17,7 +17,7 @@ if [ -z "${PACKAGE_VERSION}" ]; then
   exit 1
 fi
 
-export HZ_DISTRIBUTION_FILE=${HZ_DISTRIBUTION}-distribution-${HZ_VERSION}.tar.gz
+export HZ_DISTRIBUTION_FILE=distribution.tar.gz
 
 if [ ! -f "${HZ_DISTRIBUTION_FILE}" ]; then
   echo "File ${HZ_DISTRIBUTION_FILE} doesn't exits in current directory."

--- a/build-hazelcast-homebrew-package.sh
+++ b/build-hazelcast-homebrew-package.sh
@@ -17,7 +17,7 @@ if [ -z "${PACKAGE_VERSION}" ]; then
   exit 1
 fi
 
-export HZ_DISTRIBUTION_FILE=${HZ_DISTRIBUTION}-distribution-${HZ_VERSION}.tar.gz
+export HZ_DISTRIBUTION_FILE=distribution.tar.gz
 
 if [ ! -f "${HZ_DISTRIBUTION_FILE}" ]; then
   echo "File ${HZ_DISTRIBUTION_FILE} doesn't exits in current directory."

--- a/build-hazelcast-rpm-package.sh
+++ b/build-hazelcast-rpm-package.sh
@@ -19,7 +19,7 @@ if [ -z "${PACKAGE_VERSION}" ]; then
   exit 1
 fi
 
-export HZ_DISTRIBUTION_FILE=${HZ_DISTRIBUTION}-distribution-${HZ_VERSION}.tar.gz
+export HZ_DISTRIBUTION_FILE=distribution.tar.gz
 
 if [ ! -f "${HZ_DISTRIBUTION_FILE}" ]; then
   echo "File ${HZ_DISTRIBUTION_FILE} doesn't exits in current directory."


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-packaging/pull/207
- Use internal snapshot maven repository for getting OSS snapshot distribution zip
- Do not produce brew packages for OSS snapshot as it would expose password-protected urls

Fixes https://hazelcast.atlassian.net/browse/DI-154

Implemented similar like hazelcast-docker: https://github.com/hazelcast/hazelcast-docker/pull/774
