### PR TITLE
Use internal snapshot repository for OSS snapshot packages [DI-154][5.5.z]

### DIFF
--- a/.github/workflows/build.functions.sh
+++ b/.github/workflows/build.functions.sh
@@ -32,3 +32,36 @@ function should_build_ee() {
   fi
 }
 
+function get_hz_dist_tar_gz() {
+  local hz_version=$1
+  local distribution=$2
+  local extension=tar.gz
+  local url
+
+  if [[ "$distribution" == "hazelcast" ]]; then
+    if [[ "${hz_version}" == *"SNAPSHOT"* ]]; then
+      url="https://${HZ_SNAPSHOT_INTERNAL_USERNAME}:${HZ_SNAPSHOT_INTERNAL_PASSWORD}@repository.hazelcast.com/snapshot-internal/com/hazelcast/hazelcast-distribution/${hz_version}/hazelcast-distribution-${hz_version}.$extension"
+    else
+      url="https://repo1.maven.org/maven2/com/hazelcast/hazelcast-distribution/${hz_version}/hazelcast-distribution-${hz_version}.$extension"
+    fi
+  elif [[ "$distribution" == "hazelcast-enterprise" ]]; then
+    local repository
+    if [[ "${hz_version}" == *"SNAPSHOT"* ]]; then
+      repository=snapshot
+    else
+      repository=release
+    fi
+    url="https://repository.hazelcast.com/${repository}/com/hazelcast/hazelcast-enterprise-distribution/${hz_version}/hazelcast-enterprise-distribution-${hz_version}.$extension"
+  fi
+  echo "$url"
+}
+
+function url_contains_password() {
+  local url=$1
+  local password=$2
+  if [[ "$url" == *"$password"* ]]; then
+    echo "yes"
+  else
+    echo "no"
+  fi
+}

--- a/.github/workflows/build.functions_tests.sh
+++ b/.github/workflows/build.functions_tests.sh
@@ -48,4 +48,32 @@ assert_should_build_ee "pull_request" "ALL" "yes"
 assert_should_build_ee "pull_request" "OSS" "yes"
 assert_should_build_ee "pull_request" "EE" "yes"
 
+function assert_get_hz_dist_tar_gz {
+  local hz_version=$1
+  local distribution=$2
+  local expected_url=$3
+  local actual_url=$(get_hz_dist_tar_gz "$hz_version" "$distribution")
+  assert_eq "$expected_url" "$actual_url" "Expected URL for version \"$hz_version\", distribution \"$distribution\"" || TESTS_RESULT=$?
+}
+
+log_header "Tests for get_hz_dist_tar_gz"
+export HZ_SNAPSHOT_INTERNAL_USERNAME=dummy_user
+export HZ_SNAPSHOT_INTERNAL_PASSWORD=dummy_password
+assert_get_hz_dist_tar_gz 5.4.0 hazelcast https://repo1.maven.org/maven2/com/hazelcast/hazelcast-distribution/5.4.0/hazelcast-distribution-5.4.0.tar.gz
+assert_get_hz_dist_tar_gz 5.5.0-SNAPSHOT hazelcast https://dummy_user:dummy_password@repository.hazelcast.com/snapshot-internal/com/hazelcast/hazelcast-distribution/5.5.0-SNAPSHOT/hazelcast-distribution-5.5.0-SNAPSHOT.tar.gz
+
+assert_get_hz_dist_tar_gz 5.4.0 hazelcast-enterprise https://repository.hazelcast.com/release/com/hazelcast/hazelcast-enterprise-distribution/5.4.0/hazelcast-enterprise-distribution-5.4.0.tar.gz
+assert_get_hz_dist_tar_gz 5.5.0-SNAPSHOT hazelcast-enterprise https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.5.0-SNAPSHOT/hazelcast-enterprise-distribution-5.5.0-SNAPSHOT.tar.gz
+
+function assert_url_contains_password {
+  local url=$1
+  local password=$2
+  local expected_result=$3
+  local actual=$(url_contains_password "$url" "$password")
+  assert_eq "$expected_result" "$actual" "Url '$url' should$( [ "$expected_result" = "no" ] && echo " NOT") contain $password" || TESTS_RESULT=$?
+}
+
+assert_url_contains_password "https://dummy_user:dummy_password@repository.hazelcast.com/snapshot-internal/com/hazelcast/hazelcast-distribution/5.5.0-SNAPSHOT/hazelcast-distribution-5.5.0-SNAPSHOT.tar.gz" "dummy_password" "yes"
+assert_url_contains_password "https://repo1.maven.org/maven2/com/hazelcast/hazelcast-distribution/5.4.0/hazelcast-distribution-5.4.0.tar.gz" "dummy_password" "no"
+
 assert_eq 0 "$TESTS_RESULT" "ALL tests should pass"

--- a/.github/workflows/publish-brew-package.yml
+++ b/.github/workflows/publish-brew-package.yml
@@ -55,10 +55,18 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Download the distribution tar.gz file
+        env:
+          HZ_SNAPSHOT_INTERNAL_PASSWORD: ${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
+          HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
         run: |
-          HZ_PACKAGE_URL=$(mvn --batch-mode dependency:copy -Dartifact=com.hazelcast:${HZ_DISTRIBUTION}-distribution:${HZ_VERSION}:tar.gz \
-          -DoutputDirectory=./ -Dmdep.useBaseVersion=true | grep 'Downloaded from' | grep -Eo "https://[^ >]+${HZ_DISTRIBUTION}-distribution-.*.tar.gz")
-          echo "HZ_PACKAGE_URL=$HZ_PACKAGE_URL" >> $GITHUB_ENV
+          . .github/workflows/build.functions.sh
+          DISTRIBUTION_URL=$(get_hz_dist_tar_gz "${HZ_VERSION}" "${HZ_DISTRIBUTION}")
+          if [[ "$(url_contains_password "$DISTRIBUTION_URL" "$HZ_SNAPSHOT_INTERNAL_PASSWORD")" == "yes" ]]; then
+             echo "Trying to expose a password-protected url of the distribution file, aborting!";
+             exit 1;
+          fi
+          curl --fail --silent --show-error --location "${DISTRIBUTION_URL}" --output distribution.tar.gz 
+          echo "HZ_PACKAGE_URL=${DISTRIBUTION_URL}" >> $GITHUB_ENV
 
       - name: Get homebrew repository
         run: |
@@ -112,3 +120,10 @@ jobs:
         run: |
           source ./common.sh          
           brew uninstall ${{ env.HZ_DISTRIBUTION}}@$BREW_PACKAGE_VERSION
+
+      - name: Store logs as artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: brew-${{ env.HZ_DISTRIBUTION}}-hz.log
+          path: hz.log

--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -48,9 +48,13 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Download the distribution tar.gz file
+        env:
+          HZ_SNAPSHOT_INTERNAL_PASSWORD: ${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
+          HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
         run: |
-          mvn --batch-mode dependency:copy -Dartifact=com.hazelcast:${HZ_DISTRIBUTION}-distribution:${HZ_VERSION}:tar.gz \
-          -DoutputDirectory=./ -Dmdep.useBaseVersion=true
+          . .github/workflows/build.functions.sh
+          DISTRIBUTION_URL=$(get_hz_dist_tar_gz "${HZ_VERSION}" "${HZ_DISTRIBUTION}")
+          curl --fail --silent --show-error --location "$DISTRIBUTION_URL" --output distribution.tar.gz 
 
       - name: Create & Upload DEB package
         run: |
@@ -89,3 +93,10 @@ jobs:
           curl -H "Authorization: Bearer ${{ env.JFROG_TOKEN }}" \
             -X DELETE \
             "$DEBIAN_REPO_BASE_URL/${HZ_DISTRIBUTION}-${DEB_PACKAGE_VERSION}-all.deb"
+
+      - name: Store logs as artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: deb-${{ env.HZ_DISTRIBUTION}}-hz.log
+          path: hz.log

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -157,7 +157,7 @@ jobs:
      USE_TEST_REPO: ${{ needs.prepare.outputs.use_test_repo }}
   brew-oss:
     needs: [ prepare ]
-    if: needs.prepare.outputs.should_build_homebrew == 'true' && needs.prepare.outputs.should_build_oss == 'yes'
+    if: needs.prepare.outputs.should_build_homebrew == 'true' && needs.prepare.outputs.should_build_oss == 'yes' && !contains(needs.prepare.outputs.hz_version, 'SNAPSHOT')
     uses: ./.github/workflows/publish-brew-package.yml
     secrets: inherit
     with:

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -54,9 +54,13 @@ jobs:
           yum install -y maven rpm-sign rpm-build wget gettext systemd-rpm-macros
 
       - name: Download the distribution tar.gz file
+        env:
+          HZ_SNAPSHOT_INTERNAL_PASSWORD: ${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
+          HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
         run: |
-          mvn --batch-mode dependency:copy -Dartifact=com.hazelcast:${HZ_DISTRIBUTION}-distribution:${HZ_VERSION}:tar.gz \
-          -DoutputDirectory=./ -Dmdep.useBaseVersion=true
+          . .github/workflows/build.functions.sh
+          DISTRIBUTION_URL=$(get_hz_dist_tar_gz "${HZ_VERSION}" "${HZ_DISTRIBUTION}")
+          curl --fail --silent --show-error --location "$DISTRIBUTION_URL" --output distribution.tar.gz 
 
       - name: Create & Sign & Upload RPM package
         run: |
@@ -97,3 +101,10 @@ jobs:
           curl -H "Authorization: Bearer ${{ env.JFROG_TOKEN }}" \
             -X DELETE \
             "$RPM_REPO_BASE_URL/${PACKAGE_REPO}/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm"
+
+      - name: Store logs as artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpm-${{ env.HZ_DISTRIBUTION}}-hz.log
+          path: hz.log

--- a/build-hazelcast-deb-package.sh
+++ b/build-hazelcast-deb-package.sh
@@ -17,14 +17,13 @@ if [ -z "${PACKAGE_VERSION}" ]; then
   exit 1
 fi
 
-export HZ_DISTRIBUTION_FILE=${HZ_DISTRIBUTION}-distribution-${HZ_VERSION}.tar.gz
+source common.sh
 
 if [ ! -f "${HZ_DISTRIBUTION_FILE}" ]; then
   echo "File ${HZ_DISTRIBUTION_FILE} doesn't exits in current directory."
   exit 1;
 fi
 
-source common.sh
 
 echo "Building DEB package $HZ_DISTRIBUTION:${HZ_VERSION} package version ${DEB_PACKAGE_VERSION}"
 

--- a/build-hazelcast-homebrew-package.sh
+++ b/build-hazelcast-homebrew-package.sh
@@ -17,12 +17,6 @@ if [ -z "${PACKAGE_VERSION}" ]; then
   exit 1
 fi
 
-export HZ_DISTRIBUTION_FILE=${HZ_DISTRIBUTION}-distribution-${HZ_VERSION}.tar.gz
-
-if [ ! -f "${HZ_DISTRIBUTION_FILE}" ]; then
-  echo "File ${HZ_DISTRIBUTION_FILE} doesn't exits in current directory."
-  exit 1;
-fi
 
 # With Homebrew we actually don't upload the artifact anywhere, but use the base tar.gz artifact url.
 # The package manager then downloads it from there.
@@ -34,6 +28,11 @@ fi
 
 source common.sh
 source packages/brew/functions.sh
+
+if [ ! -f "${HZ_DISTRIBUTION_FILE}" ]; then
+  echo "File ${HZ_DISTRIBUTION_FILE} doesn't exits in current directory."
+  exit 1;
+fi
 
 echo "Building Homebrew package $HZ_DISTRIBUTION:${HZ_VERSION} package version ${PACKAGE_VERSION}"
 

--- a/build-hazelcast-rpm-package.sh
+++ b/build-hazelcast-rpm-package.sh
@@ -19,14 +19,12 @@ if [ -z "${PACKAGE_VERSION}" ]; then
   exit 1
 fi
 
-export HZ_DISTRIBUTION_FILE=${HZ_DISTRIBUTION}-distribution-${HZ_VERSION}.tar.gz
+source common.sh
 
 if [ ! -f "${HZ_DISTRIBUTION_FILE}" ]; then
   echo "File ${HZ_DISTRIBUTION_FILE} doesn't exits in current directory."
   exit 1;
 fi
-
-source common.sh
 
 echo "Building RPM package $HZ_DISTRIBUTION:${HZ_VERSION} package version ${RPM_PACKAGE_VERSION}"
 

--- a/common.sh
+++ b/common.sh
@@ -77,3 +77,5 @@ else
   export BREW_GIT_REPO_NAME="hazelcast/homebrew-hz"
   export BREW_TAP_NAME="hazelcast/hz"
 fi
+
+export HZ_DISTRIBUTION_FILE=distribution.tar.gz


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-packaging/pull/207

- Use internal snapshot maven repository for getting OSS snapshot distribution zip
- Do not produce brew packages for OSS snapshot as it would expose password-protected urls

Fixes https://hazelcast.atlassian.net/browse/DI-154

Implemented similar like hazelcast-docker: https://github.com/hazelcast/hazelcast-docker/pull/774