### PR TITLE
Extend package validation tests as per `hazelcast-docker` [DI-215]

### DIFF
--- a/.github/workflows/publish-brew-package.yml
+++ b/.github/workflows/publish-brew-package.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Check Hazelcast health
         run: |
-          ./check-hazelcast-health.sh ${{ env.HZ_DISTRIBUTION}} ${{ env.HZ_VERSION}}
+          ./check-hazelcast-health.sh "${{ env.HZ_DISTRIBUTION}}" "${{ env.HZ_VERSION}}"
 
       - name: Uninstall Hazelcast from homebrew
         run: |

--- a/.github/workflows/publish-brew-package.yml
+++ b/.github/workflows/publish-brew-package.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Check Hazelcast health
         run: |
-          ./check-hazelcast-health.sh
+          ./check-hazelcast-health.sh ${{ env.HZ_DISTRIBUTION}} ${{ env.HZ_VERSION}}
 
       - name: Uninstall Hazelcast from homebrew
         run: |

--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Check Hazelcast health
         run: |
-          ./check-hazelcast-health.sh
+          ./check-hazelcast-health.sh ${{ env.HZ_DISTRIBUTION}} ${{ env.HZ_VERSION}}
 
       - name: Uninstall Hazelcast from deb
         run: |

--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Check Hazelcast health
         run: |
-          ./check-hazelcast-health.sh ${{ env.HZ_DISTRIBUTION}} ${{ env.HZ_VERSION}}
+          ./check-hazelcast-health.sh "${{ env.HZ_DISTRIBUTION}}" "${{ env.HZ_VERSION}}"
 
       - name: Uninstall Hazelcast from deb
         run: |

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Check Hazelcast health
         run: |
-          ./check-hazelcast-health.sh ${{ env.HZ_DISTRIBUTION}} ${{ env.HZ_VERSION}}
+          ./check-hazelcast-health.sh "${{ env.HZ_DISTRIBUTION}}" "${{ env.HZ_VERSION}}"
 
       - name: Uninstall Hazelcast from rpm
         run: |

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Check Hazelcast health
         run: |
-          ./check-hazelcast-health.sh
+          ./check-hazelcast-health.sh ${{ env.HZ_DISTRIBUTION}} ${{ env.HZ_VERSION}}
 
       - name: Uninstall Hazelcast from rpm
         run: |

--- a/check-hazelcast-health.sh
+++ b/check-hazelcast-health.sh
@@ -6,12 +6,12 @@ set -x
 
 # Source the latest version of `abstract-simple-smoke-test.sh` from the `hazelcast-docker` repository and include in current shell
 # TODO Use `master` once merged
-#abstract_simple_smoke_test_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/DI-215-Add-additional-Deb/RPM/Brew-tests/.github/scripts/abstract-simple-smoke-test.sh)
-curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/DI-215-Add-additional-Deb/RPM/Brew-tests/.github/scripts/abstract-simple-smoke-test.sh -o abstract-simple-smoke-test.sh
-cat abstract-simple-smoke-test.sh
+curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/DI-215-Add-additional-Deb/RPM/Brew-tests/.github/scripts/abstract-simple-smoke-test.sh --output abstract-simple-smoke-test.sh
 
 # shellcheck source=/dev/null
-#. <(echo "${abstract_simple_smoke_test_script_content}")
+# You _should_ be able to avoid a temporary file with something like
+# . <(echo "${abstract_simple_smoke_test_script_content}")
+# But this doesn't work on the MacOS GitHub runner (but does on MacOS locally)
 . abstract-simple-smoke-test.sh
 
 function get_hz_logs() {

--- a/check-hazelcast-health.sh
+++ b/check-hazelcast-health.sh
@@ -1,13 +1,10 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -o errexit
 
 # Source the latest version of `abstract-simple-smoke-test.sh` from the `hazelcast-docker` repository and include in current shell
 # TODO Use `master` once merged
 abstract_simple_smoke_test_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/DI-215-Add-additional-Deb/RPM/Brew-tests/.github/scripts/abstract-simple-smoke-test.sh)
-
-# TODO REMOVE
-echo "${abstract_simple_smoke_test_script_content}"
 
 # shellcheck source=/dev/null
 . <(echo "${abstract_simple_smoke_test_script_content}")

--- a/check-hazelcast-health.sh
+++ b/check-hazelcast-health.sh
@@ -1,15 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-attempts=0
-max_attempts=30
-until $(curl --silent --fail "127.0.0.1:5701/hazelcast/health/ready"); do
-  if [ ${attempts} -eq ${max_attempts} ];then
-      echo "Hazelcast not responding"
-      cat hz.log
-      ps -aux
-      exit 1
-  fi
-  printf '.'
-  attempts=$(($attempts+1))
-  sleep 2
-done
+set -o errexit
+
+# Source the latest version of `abstract-simple-smoke-test.sh` from the `hazelcast-docker` repository and include in current shell
+# TODO Use `master` once merged
+abstract_simple_smoke_test_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/DI-215-Add-additional-Deb/RPM/Brew-tests/.github/scripts/abstract-simple-smoke-test.sh)
+# shellcheck source=/dev/null
+. <(echo "${abstract_simple_smoke_test_script_content}")
+
+function get_logs() {
+    cat hz.log
+}
+
+input_distribution_type=$1
+expected_version=$2
+
+case "${input_distribution_type}" in
+  "hazelcast")
+    expected_distribution_type="Hazelcast Platform"
+    ;;
+  "hazelcast-enterprise")
+    expected_distribution_type="Hazelcast Enterprise"
+    ;;
+  *)
+    echoerr "Unrecognized distribution type ${input_distribution_type}"
+    exit 1
+    ;;
+esac
+
+test_package "${expected_distribution_type}" "${expected_version}"

--- a/check-hazelcast-health.sh
+++ b/check-hazelcast-health.sh
@@ -5,8 +5,7 @@ set -o errexit
 set -x
 
 # Source the latest version of `abstract-simple-smoke-test.sh` from the `hazelcast-docker` repository and include in current shell
-# TODO Use `master` once merged
-curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/DI-215-Add-additional-Deb/RPM/Brew-tests/.github/scripts/abstract-simple-smoke-test.sh --output abstract-simple-smoke-test.sh
+curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/master/.github/scripts/abstract-simple-smoke-test.sh --output abstract-simple-smoke-test.sh
 
 # shellcheck source=/dev/null
 # You _should_ be able to avoid a temporary file with something like

--- a/check-hazelcast-health.sh
+++ b/check-hazelcast-health.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 
 set -o errexit
+# TODO REMOVE
+set -x
 
 # Source the latest version of `abstract-simple-smoke-test.sh` from the `hazelcast-docker` repository and include in current shell
 # TODO Use `master` once merged
-abstract_simple_smoke_test_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/DI-215-Add-additional-Deb/RPM/Brew-tests/.github/scripts/abstract-simple-smoke-test.sh)
-
-# TODO REMOVE
-echo "${abstract_simple_smoke_test_script_content}"
+#abstract_simple_smoke_test_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/DI-215-Add-additional-Deb/RPM/Brew-tests/.github/scripts/abstract-simple-smoke-test.sh)
+curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/DI-215-Add-additional-Deb/RPM/Brew-tests/.github/scripts/abstract-simple-smoke-test.sh -o abstract-simple-smoke-test.sh
+cat abstract-simple-smoke-test.sh
 
 # shellcheck source=/dev/null
-. <(echo "${abstract_simple_smoke_test_script_content}")
+#. <(echo "${abstract_simple_smoke_test_script_content}")
+. abstract-simple-smoke-test.sh
 
 function get_hz_logs() {
     cat hz.log

--- a/check-hazelcast-health.sh
+++ b/check-hazelcast-health.sh
@@ -5,6 +5,10 @@ set -o errexit
 # Source the latest version of `abstract-simple-smoke-test.sh` from the `hazelcast-docker` repository and include in current shell
 # TODO Use `master` once merged
 abstract_simple_smoke_test_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/DI-215-Add-additional-Deb/RPM/Brew-tests/.github/scripts/abstract-simple-smoke-test.sh)
+
+# TODO REMOVE
+echo "${abstract_simple_smoke_test_script_content}"
+
 # shellcheck source=/dev/null
 . <(echo "${abstract_simple_smoke_test_script_content}")
 

--- a/check-hazelcast-health.sh
+++ b/check-hazelcast-health.sh
@@ -8,7 +8,7 @@ abstract_simple_smoke_test_script_content=$(curl --silent https://raw.githubuser
 # shellcheck source=/dev/null
 . <(echo "${abstract_simple_smoke_test_script_content}")
 
-function get_logs() {
+function get_hz_logs() {
     cat hz.log
 }
 

--- a/check-hazelcast-health.sh
+++ b/check-hazelcast-health.sh
@@ -18,20 +18,25 @@ function get_hz_logs() {
     cat hz.log
 }
 
+function derive_expected_distribution_type() {
+  local input_distribution_type=$1
+
+  case "${input_distribution_type}" in
+    "hazelcast")
+      echo "Hazelcast Platform"
+      ;;
+    "hazelcast-enterprise")
+      echo "Hazelcast Enterprise"
+      ;;
+    *)
+      echoerr "Unrecognized distribution type ${input_distribution_type}"
+      exit 1
+      ;;
+  esac
+}
+
 input_distribution_type=$1
 expected_version=$2
 
-case "${input_distribution_type}" in
-  "hazelcast")
-    expected_distribution_type="Hazelcast Platform"
-    ;;
-  "hazelcast-enterprise")
-    expected_distribution_type="Hazelcast Enterprise"
-    ;;
-  *)
-    echoerr "Unrecognized distribution type ${input_distribution_type}"
-    exit 1
-    ;;
-esac
-
+expected_distribution_type=$(derive_expected_distribution_type "${input_distribution_type}")
 test_package "${expected_distribution_type}" "${expected_version}"

--- a/check-hazelcast-health.sh
+++ b/check-hazelcast-health.sh
@@ -1,10 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 
 # Source the latest version of `abstract-simple-smoke-test.sh` from the `hazelcast-docker` repository and include in current shell
 # TODO Use `master` once merged
 abstract_simple_smoke_test_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/DI-215-Add-additional-Deb/RPM/Brew-tests/.github/scripts/abstract-simple-smoke-test.sh)
+
+# TODO REMOVE
+echo "${abstract_simple_smoke_test_script_content}"
 
 # shellcheck source=/dev/null
 . <(echo "${abstract_simple_smoke_test_script_content}")

--- a/config/integration-test-hazelcast.yaml
+++ b/config/integration-test-hazelcast.yaml
@@ -1,5 +1,5 @@
 hazelcast:
-  cluster-name: hz-it-cluster
+  cluster-name: dev
   properties:
     hazelcast.socket.bind.any: false
   network:

--- a/config/integration-test-hazelcast.yaml
+++ b/config/integration-test-hazelcast.yaml
@@ -1,12 +1,5 @@
 hazelcast:
-  cluster-name: dev
-  properties:
-    hazelcast.socket.bind.any: false
   network:
-    interfaces:
-      enabled: true
-      interfaces:
-        - 127.0.0.1
     rest-api:
       enabled: true
       endpoint-groups:


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-docker/pull/776, additional checks were added to `hazelcast-docker`'s tests to assert variant and version.

Rather than duplicate these tests, here, instead refactored those tests so that the logic can be shared - https://github.com/hazelcast/hazelcast-docker/pull/790

This PR adapts these tests to use this framework, giving additional validation:
- variant and version
- `CLC` can connect to `IMap` in instance

Fixes: [DI-215](https://hazelcast.atlassian.net/browse/DI-215)

[DI-215]: https://hazelcast.atlassian.net/browse/DI-215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ