### PR TITLE
Make `test-local` repos private [DI-222]

### DIFF
--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -72,7 +72,13 @@ jobs:
           HZ_LICENSEKEY: ${{ secrets.HZ_LICENSEKEY }}
         run: |
           source ./common.sh
-          wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
+          wget \
+            https://repository.hazelcast.com/api/gpg/key/public \
+            --header "Authorization: Bearer ${{ env.JFROG_TOKEN }}" \
+            --output-document - \
+            --quiet \
+            | gpg --dearmor \
+            | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
           echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] ${DEBIAN_REPO_BASE_URL} ${PACKAGE_REPO} main" | sudo tee -a /etc/apt/sources.list
           sudo apt update && sudo apt install ${{ env.HZ_DISTRIBUTION}}=${HZ_VERSION}
           HAZELCAST_CONFIG="$(pwd)/config/integration-test-hazelcast.yaml" hz-start > hz.log 2>&1 &

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -80,7 +80,10 @@ jobs:
           HZ_LICENSEKEY: ${{ secrets.HZ_LICENSEKEY }}
         run: |
           source ./common.sh
-          wget ${RPM_REPO_BASE_URL}/${PACKAGE_REPO}/hazelcast-rpm-${PACKAGE_REPO}.repo -O hazelcast-rpm-${PACKAGE_REPO}.repo
+          wget \
+            ${RPM_REPO_BASE_URL}/${PACKAGE_REPO}/hazelcast-rpm-${PACKAGE_REPO}.repo \
+            --header "Authorization: Bearer ${{ env.JFROG_TOKEN }}" \
+            --output-document hazelcast-rpm-${PACKAGE_REPO}.repo
           mv hazelcast-rpm-${PACKAGE_REPO}.repo /etc/yum.repos.d/          
           yum install -y ${{ env.HZ_DISTRIBUTION}}-${RPM_HZ_VERSION}
           HAZELCAST_CONFIG="$(pwd)/config/integration-test-hazelcast.yaml" hz-start > hz.log 2>&1 &


### PR DESCRIPTION
As part of removing publically available `SNAPSHOT`s, the test repos do not need to publically accessible.

Before we can do this, however, we need to ensure that the test requests are properly authorized.

Fixes: [DI-222](https://hazelcast.atlassian.net/browse/DI-222)

Post-merge:
- [ ] Backport to all maintenance branches

[DI-222]: https://hazelcast.atlassian.net/browse/DI-222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ