### PR TITLE
Fix private test repository access [DI-236]

### DIFF
--- a/.github/workflows/publish-brew-package.yml
+++ b/.github/workflows/publish-brew-package.yml
@@ -19,6 +19,10 @@ on:
         description: 'Version of the package e.g. 5.1.1, 5.1.1-1, defaults to HZ_VERSION'
         type: string
 
+env:
+  JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
+  JFROG_TOKEN: ${{ secrets.JFROG_TOKEN }}
+
 concurrency:
   group: 'brew-${{ github.job }}-${{ inputs.HZ_VERSION }}-${{ inputs.HZ_DISTRIBUTION}}'
 

--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -20,6 +20,7 @@ on:
         type: string
 
 env:
+  JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
   JFROG_TOKEN: ${{ secrets.JFROG_TOKEN }}
 
 concurrency:

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -87,8 +87,7 @@ jobs:
             ${RPM_REPO_BASE_URL}/${PACKAGE_REPO}/hazelcast-rpm-${PACKAGE_REPO}.repo \
             --header "Authorization: Bearer ${{ env.JFROG_TOKEN }}" \
             --output-document - | \
-          sed \
-            "s#\(https\?://\)#\1${{ secrets.JFROG_USERNAME }}:${{ secrets.JFROG_TOKEN }}@#g" > \
+          sed "s#\(https://\)#\1${{ secrets.JFROG_USERNAME }}:${{ secrets.JFROG_TOKEN }}@#g" > \
           /etc/yum.repos.d/hazelcast-rpm-${PACKAGE_REPO}.repo
 
           yum install -y ${{ env.HZ_DISTRIBUTION}}-${RPM_HZ_VERSION}

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -87,7 +87,7 @@ jobs:
             ${RPM_REPO_BASE_URL}/${PACKAGE_REPO}/hazelcast-rpm-${PACKAGE_REPO}.repo \
             --header "Authorization: Bearer ${{ env.JFROG_TOKEN }}" \
             --output-document - | \
-          sed "s#https://#https://${{ secrets.JFROG_USERNAME }}:${{ secrets.JFROG_TOKEN }}@#g" > \
+          sed "s#https://#https://${{ env.JFROG_USERNAME }}:${{ env.JFROG_TOKEN }}@#g" > \
           /etc/yum.repos.d/hazelcast-rpm-${PACKAGE_REPO}.repo
 
           yum install -y ${{ env.HZ_DISTRIBUTION}}-${RPM_HZ_VERSION}

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -85,6 +85,10 @@ jobs:
             ${RPM_REPO_BASE_URL}/${PACKAGE_REPO}/hazelcast-rpm-${PACKAGE_REPO}.repo \
             --header "Authorization: Bearer ${{ env.JFROG_TOKEN }}" \
             --output-document hazelcast-rpm-${PACKAGE_REPO}.repo
+
+          # Bake authentication into the returned URLs
+          sed --in-place "s#\(https\?://\)#\1${{ secrets.JFROG_USERNAME }}:${{ secrets.JFROG_TOKEN }}@#g" hazelcast-rpm-${PACKAGE_REPO}.repo
+
           mv hazelcast-rpm-${PACKAGE_REPO}.repo /etc/yum.repos.d/          
           yum install -y ${{ env.HZ_DISTRIBUTION}}-${RPM_HZ_VERSION}
           HAZELCAST_CONFIG="$(pwd)/config/integration-test-hazelcast.yaml" hz-start > hz.log 2>&1 &

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -87,7 +87,7 @@ jobs:
             ${RPM_REPO_BASE_URL}/${PACKAGE_REPO}/hazelcast-rpm-${PACKAGE_REPO}.repo \
             --header "Authorization: Bearer ${{ env.JFROG_TOKEN }}" \
             --output-document - | \
-          sed "s#\(https://\)#\1${{ secrets.JFROG_USERNAME }}:${{ secrets.JFROG_TOKEN }}@#g" > \
+          sed "s#\(https://\)#\1${{ env.JFROG_USERNAME }}:${{ env.JFROG_TOKEN }}@#g" > \
           /etc/yum.repos.d/hazelcast-rpm-${PACKAGE_REPO}.repo
 
           yum install -y ${{ env.HZ_DISTRIBUTION}}-${RPM_HZ_VERSION}

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -81,15 +81,16 @@ jobs:
           HZ_LICENSEKEY: ${{ secrets.HZ_LICENSEKEY }}
         run: |
           source ./common.sh
+
+          # Bake authentication into the returned URLs
           wget \
             ${RPM_REPO_BASE_URL}/${PACKAGE_REPO}/hazelcast-rpm-${PACKAGE_REPO}.repo \
             --header "Authorization: Bearer ${{ env.JFROG_TOKEN }}" \
-            --output-document hazelcast-rpm-${PACKAGE_REPO}.repo
+            --output-document - | \
+          sed \
+            "s#\(https\?://\)#\1${{ secrets.JFROG_USERNAME }}:${{ secrets.JFROG_TOKEN }}@#g" > \
+          /etc/yum.repos.d/hazelcast-rpm-${PACKAGE_REPO}.repo
 
-          # Bake authentication into the returned URLs
-          sed --in-place "s#\(https\?://\)#\1${{ secrets.JFROG_USERNAME }}:${{ secrets.JFROG_TOKEN }}@#g" hazelcast-rpm-${PACKAGE_REPO}.repo
-
-          mv hazelcast-rpm-${PACKAGE_REPO}.repo /etc/yum.repos.d/          
           yum install -y ${{ env.HZ_DISTRIBUTION}}-${RPM_HZ_VERSION}
           HAZELCAST_CONFIG="$(pwd)/config/integration-test-hazelcast.yaml" hz-start > hz.log 2>&1 &
 

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -20,6 +20,7 @@ on:
         type: string
 
 env:
+  JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
   JFROG_TOKEN: ${{ secrets.JFROG_TOKEN }}
   DEVOPS_PRIVATE_KEY: ${{ secrets.DEVOPS_PRIVATE_KEY }}
   BINTRAY_PASSPHRASE: ${{ secrets.BINTRAY_PASSPHRASE }}

--- a/common.sh
+++ b/common.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -o errexit -o nounset -o pipefail
 
 if [ -z "${USE_TEST_REPO}" ]; then
   echo "Variable USE_TEST_REPO is not set."

--- a/common.sh
+++ b/common.sh
@@ -63,7 +63,6 @@ if [ "${USE_TEST_REPO}" == "true" ]; then
   export DEBIAN_REPO=debian-test-local
   export DEBIAN_REPO_BASE_URL="https://${JFROG_USERNAME}:${JFROG_TOKEN}@repository.hazelcast.com/${DEBIAN_REPO}"
   export RPM_REPO=rpm-test-local
-  export RPM_REPO_BASE_URL="https://repository.hazelcast.com/${RPM_REPO}"
 
   # This is a clone of the hazelcast/homebrew-hz repository
   export BREW_GIT_REPO_NAME="hazelcast/homebrew-hz-test"
@@ -72,10 +71,10 @@ else
   export DEBIAN_REPO=debian-local
   export DEBIAN_REPO_BASE_URL="https://repository.hazelcast.com/${DEBIAN_REPO}"
   export RPM_REPO=rpm-local
-  export RPM_REPO_BASE_URL="https://repository.hazelcast.com/${RPM_REPO}"
 
   export BREW_GIT_REPO_NAME="hazelcast/homebrew-hz"
   export BREW_TAP_NAME="hazelcast/hz"
 fi
 
+export RPM_REPO_BASE_URL="https://repository.hazelcast.com/${RPM_REPO}"
 export HZ_DISTRIBUTION_FILE=distribution.tar.gz

--- a/common.sh
+++ b/common.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o errexit -o nounset -o pipefail
 
 if [ -z "${USE_TEST_REPO}" ]; then
   echo "Variable USE_TEST_REPO is not set."
@@ -61,7 +62,7 @@ export BREW_PACKAGE_VERSION
 if [ "${USE_TEST_REPO}" == "true" ]; then
   # PRs publish to test repositories and install the packages from there
   export DEBIAN_REPO=debian-test-local
-  export DEBIAN_REPO_BASE_URL="https://repository.hazelcast.com/${DEBIAN_REPO}"
+  export DEBIAN_REPO_BASE_URL="https://${JFROG_USERNAME}:${JFROG_TOKEN}@repository.hazelcast.com/${DEBIAN_REPO}"
   export RPM_REPO=rpm-test-local
   export RPM_REPO_BASE_URL="https://repository.hazelcast.com/${RPM_REPO}"
 


### PR DESCRIPTION
In [DI-222](https://hazelcast.atlassian.net/browse/DI-222) the test repositories were made private, but that caused [build failures](https://github.com/hazelcast/hazelcast-packaging/actions/runs/10365877156/job/28693937495).

While the _initial_ connection to the repositories to get metadata was authenticated, the ultimate `install` was not and failed.

Fixed by adding the credentials to the URL as advised by [JFrog documentation](https://jfrog.com/help/r/jfrog-artifactory-documentation/configure-authenticated-access-to-debian-servers)

Fixes: [DI-236](https://hazelcast.atlassian.net/browse/DI-236)

[DI-222]: https://hazelcast.atlassian.net/browse/DI-222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DI-236]: https://hazelcast.atlassian.net/browse/DI-236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ