### PR TITLE
Fix Homebrew unbound variable warning

### DIFF
--- a/packages/brew/brew_functions.sh
+++ b/packages/brew/brew_functions.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail ${RUNNER_DEBUG:+-x}
+
 function alphanumCamelCase {
   echo "$1"|  sed -r 's/(-)/\./g' | tr '[:upper:]' '[:lower:]' | sed "s/\b\(.\)/\u\1/g" | sed 's+\.++g'
 }
@@ -7,7 +9,7 @@ function alphanumCamelCase {
 # The class name used in formula must not have dots nor hyphens and must be alphanumCamelCased
 function brewClass {
   basename=$(alphanumCamelCase "$1")
-  version=$(alphanumCamelCase "$2")
+  version=$(alphanumCamelCase "${2:-}")
   if [ -n "${version}" ]; then
     version="AT${version}"
   fi


### PR DESCRIPTION
[It was highlighted](https://github.com/hazelcast/hazelcast-packaging/pull/222#pullrequestreview-2239209705) that a warning was logged:
> packages/brew/functions.sh: line 10: $2: unbound variable

- This should've been an error, not a warning - hence `set -u`
- The function is clearly designed for `$2` to be optional, so we should support that

Warning [no longer logged](https://github.com/hazelcast/hazelcast-packaging/actions/runs/10395262076/job/28786894660).