### PR TITLE
Fix `publish-rpm-package.yml` action name

### DIFF
--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -1,4 +1,4 @@
-name: Publish DEB package
+name: Publish RPM package
 
 on:
   workflow_call:


### PR DESCRIPTION
The action has the wrong name, causing confusion in the [Actions view](https://github.com/hazelcast/hazelcast-packaging/actions).

![image](https://github.com/user-attachments/assets/f3a5d7aa-ffe4-45e4-a912-a1abb41db236)
