### PR TITLE
Update `#!/usr/bin/env bash` references to `#!/bin/bash` [DI-216]

### DIFF
--- a/.github/workflows/build.functions_tests.sh
+++ b/.github/workflows/build.functions_tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"

--- a/build-hazelcast-homebrew-package.sh
+++ b/build-hazelcast-homebrew-package.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -euo pipefail ${RUNNER_DEBUG:+-x}
 

--- a/check-hazelcast-health.sh
+++ b/check-hazelcast-health.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -o errexit
 # TODO REMOVE

--- a/common_tests.sh
+++ b/common_tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 

--- a/packages/brew/brew_functions.sh
+++ b/packages/brew/brew_functions.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -euo pipefail ${RUNNER_DEBUG:+-x}
 

--- a/packages/brew/brew_functions_tests.sh
+++ b/packages/brew/brew_functions_tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 

--- a/test_scripts.sh
+++ b/test_scripts.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 


### PR DESCRIPTION
We _mostly_ use `#!/bin/bash` ([~700 references](https://github.com/search?q=org%3Ahazelcast+%22%23%21%2Fbin%2Fbash%22&type=code)), but sometimes we use `#!/usr/bin/env bash` ([~500 references](https://github.com/search?q=org%3Ahazelcast+%22%23%21%2Fusr%2Fbin%2Fenv+bash%22&type=code)).

We should be consistent.

Of note - [Google's style guide](https://google.github.io/styleguide/shellguide.html) suggests the same.

Fixes: [DI-216](https://hazelcast.atlassian.net/browse/DI-216)

[DI-216]: https://hazelcast.atlassian.net/browse/DI-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ