### PR TITLE
Replace Debian Java requirement with an available version

### DIFF
--- a/packages/deb/hazelcast/DEBIAN/control
+++ b/packages/deb/hazelcast/DEBIAN/control
@@ -5,7 +5,7 @@ Section: imdg
 Priority: optional
 Architecture: all
 Conflicts: ${CONFLICTS}
-Depends: java21-sdk-headless
+Depends: default-jdk-headless
 Maintainer: Hazelcast Platform Team <platform@hazelcast.com>
 Description: A tool that allows users to install & run Hazelcast
 Homepage: https://www.hazelcast.com/


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-packaging/pull/195, Debian was _intended_ to upgrade it's dependant JRE to `21` - but the JDK specified does not exist (`docker run --interactive --rm debian:stable bash -c "apt-get update && apt list | grep jdk"`)

Instead we should request the _latest_ JDK which currently is `17` (`docker run --interactive --rm debian:stable bash -c "apt-get update && apt-get install -y default-jdk-headless && java -version"`).

Fixes: https://github.com/hazelcast/hazelcast-packaging/issues/237