### PR TITLE
Improve tests [DI-337]

### DIFF
--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -29,6 +29,11 @@ concurrency:
 jobs:
   deb:
     runs-on: ubuntu-latest
+    container:
+      image: debian:stable
+    defaults:
+      run:
+        shell: bash
     env:
       HZ_VERSION: ${{ inputs.HZ_VERSION }}
       PACKAGE_VERSION: ${{ inputs.PACKAGE_VERSION || inputs.HZ_VERSION }}
@@ -39,14 +44,10 @@ jobs:
       - name: Checkout hazelcast-packaging repo
         uses: actions/checkout@v4
 
-      - name: Load env vars from .env file
-        run: cat .env >> $GITHUB_ENV
-
-      - name: Setup JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - name: Install prerequisites
+        run: |
+          apt-get update
+          apt-get install -y curl gettext-base gpg sudo wget
 
       - name: Download the distribution tar.gz file
         env:
@@ -94,7 +95,7 @@ jobs:
           sudo apt-get remove ${{ env.HZ_DISTRIBUTION}}
 
       - name: Remove deb package from test repo
-        if: env.USE_TEST_REPO == 'true'
+        if: ${{ env.USE_TEST_REPO == 'true' && (success() || failure()) }}
         run: |
           source ./common.sh
           curl -H "Authorization: Bearer ${{ env.JFROG_TOKEN }}" \

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -103,7 +103,7 @@ jobs:
           yum remove -y ${{ env.HZ_DISTRIBUTION}}-${RPM_PACKAGE_VERSION}
 
       - name: Remove rpm package from test repo
-        if: env.USE_TEST_REPO == 'true'
+        if: ${{ env.USE_TEST_REPO == 'true' && (success() || failure()) }}
         run: |
           source ./common.sh
           curl -H "Authorization: Bearer ${{ env.JFROG_TOKEN }}" \


### PR DESCRIPTION
https://github.com/hazelcast/hazelcast-packaging/issues/237 highlighted a gap in our test process, investigation found further issues this PR addresses:

- We test Debian packages on Ubuntu
   - A better target would be Debian, action updated to use `debian:latest` and install required tools
   - Note that this means the **build now fails** because the fix for https://github.com/hazelcast/hazelcast-packaging/issues/237 has yet to be merged - this is a good thing, as we've recreated the issue
- Unnecessary Java installation
   - The Debian package specifies a JRE, we don't need to install our own
   - This didn't obscure the issue in https://github.com/hazelcast/hazelcast-packaging/issues/237, but if there was an incompatibility in Java versions, it might've been hidden
- Test repo not reliably cleaned
   - The test undeploys the packages from the test repo, but _only_ if it completes successfully - when it [fails](https://github.com/hazelcast/hazelcast-packaging/actions/runs/11727659937/job/32669285892), it's not removed

Fixes: [DI-337](https://hazelcast.atlassian.net/browse/DI-337)

Post-merge action:
- [ ] copy to management centre

[DI-337]: https://hazelcast.atlassian.net/browse/DI-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ