### PR TITLE
Stop PR builder running when PR is edited

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -7,7 +7,6 @@ on:
     tags:
       - 'v*'
   pull_request:
-    types: [ opened, synchronize, edited ]
   workflow_dispatch:
     inputs:
       HZ_VERSION:


### PR DESCRIPTION
The PR builder runs whenever the text of a PR is edited, which is inefficient and not consistent with how other projects are configured.