### PR TITLE
Fix `Install Hazelcast from deb`'s `apt install` [DI-358]

### DIFF
--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -82,7 +82,7 @@ jobs:
             | gpg --dearmor \
             | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
           echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] ${DEBIAN_REPO_BASE_URL} ${PACKAGE_REPO} main" | sudo tee -a /etc/apt/sources.list
-          sudo apt-get update && sudo apt-get install ${{ env.HZ_DISTRIBUTION }}=${HZ_VERSION}
+          sudo apt-get update && sudo apt-get install -y ${{ env.HZ_DISTRIBUTION }}=${HZ_VERSION}
           HAZELCAST_CONFIG="$(pwd)/config/integration-test-hazelcast.yaml" hz-start > hz.log 2>&1 &
 
       - name: Check Hazelcast health


### PR DESCRIPTION
`apt install` prompts for confirmation, which caused the job to fail when not specified - with the newly added option, this is avoided.

Note that I do not understand why this is only _now_ causing a problem, as recent changes do not explain it:
- https://github.com/hazelcast/hazelcast-packaging/pull/220
   - I can reproduce this issue with both `apt-get` and `apt`
- https://github.com/hazelcast/hazelcast-packaging/pull/241
   - I can reproduce this issue with both Ubuntu and Debian

I think it should _always_ have failed.

Fixes: [DI-358](https://hazelcast.atlassian.net/browse/DI-358)

Post-merge actions:
- [ ] backport to maintenance branches

[DI-358]: https://hazelcast.atlassian.net/browse/DI-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ