### PR TITLE
Fix `Uninstall Hazelcast from deb`'s `apt remove` [DI-358]

### DIFF
--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Uninstall Hazelcast from deb
         run: |
           source ./common.sh
-          sudo apt-get remove --assume-yes ${{ env.HZ_DISTRIBUTION}}
+          sudo apt-get remove -y ${{ env.HZ_DISTRIBUTION}}
 
       - name: Remove deb package from test repo
         if: ${{ env.USE_TEST_REPO == 'true' && (success() || failure()) }}

--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Uninstall Hazelcast from deb
         run: |
           source ./common.sh
-          sudo apt-get remove ${{ env.HZ_DISTRIBUTION}}
+          sudo apt-get remove --assume-yes ${{ env.HZ_DISTRIBUTION}}
 
       - name: Remove deb package from test repo
         if: ${{ env.USE_TEST_REPO == 'true' && (success() || failure()) }}


### PR DESCRIPTION
As in https://github.com/hazelcast/hazelcast-packaging/pull/245, the [same scenario exists for `apt remove`](https://github.com/hazelcast/hazelcast-packaging/pull/245#issuecomment-2507778299).

Note that this is [not required for `apt update`](https://askubuntu.com/a/976083).

Post-merge actions:
- [ ] backport