### PR TITLE
Centralise `echoerr` function [DI-343]

### DIFF
--- a/.github/workflows/publish-brew-package.yml
+++ b/.github/workflows/publish-brew-package.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Checkout hazelcast-packaging repo
         uses: actions/checkout@v4
 
+      - name: Checkout hazelcast-docker repo
+        uses: actions/checkout@v4
+        with:
+          repository: hazelcast/hazelcast-docker
+          path: 'hazelcast-docker'
+
       - name: Load env vars from .env file
         run: cat .env >> $GITHUB_ENV
 

--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -44,6 +44,12 @@ jobs:
       - name: Checkout hazelcast-packaging repo
         uses: actions/checkout@v4
 
+      - name: Checkout hazelcast-docker repo
+        uses: actions/checkout@v4
+        with:
+          repository: hazelcast/hazelcast-docker
+          path: 'hazelcast-docker'
+
       - name: Install prerequisites
         run: |
           apt-get update

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Checkout hazelcast-packaging repo
         uses: actions/checkout@v4
 
+      - name: Checkout hazelcast-docker repo
+        uses: actions/checkout@v4
+        with:
+          repository: hazelcast/hazelcast-docker
+          path: 'hazelcast-docker'
+
       - name: Load env vars from .env file
         run: cat .env >> $GITHUB_ENV
 

--- a/check-hazelcast-health.sh
+++ b/check-hazelcast-health.sh
@@ -1,17 +1,9 @@
 #!/usr/bin/env bash
 
-set -o errexit
-# TODO REMOVE
-set -x
+set -o errexit ${RUNNER_DEBUG:+-x}
 
-# Source the latest version of `abstract-simple-smoke-test.sh` from the `hazelcast-docker` repository and include in current shell
-curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/master/.github/scripts/abstract-simple-smoke-test.sh --output abstract-simple-smoke-test.sh
-
-# shellcheck source=/dev/null
-# You _should_ be able to avoid a temporary file with something like
-# . <(echo "${abstract_simple_smoke_test_script_content}")
-# But this doesn't work on the MacOS GitHub runner (but does on MacOS locally)
-. abstract-simple-smoke-test.sh
+# shellcheck source=../hazelcast-docker/.github/scripts/abstract-simple-smoke-test.sh
+. hazelcast-docker/.github/scripts/abstract-simple-smoke-test.sh
 
 function get_hz_logs() {
     cat hz.log


### PR DESCRIPTION
Currently is duplicated and should instead be centralised.

[Raised from PR feedback](https://github.com/hazelcast/hazelcast-docker/pull/823#discussion_r1865712579).

Relates to https://github.com/hazelcast/hazelcast-docker/pull/842.