### PR TITLE
RPM - Support `release_notes.txt` in distribution `ZIP` [DI-358][5.4.z]

### DIFF
--- a/packages/rpm/hazelcast.spec
+++ b/packages/rpm/hazelcast.spec
@@ -92,6 +92,7 @@ printf "\n\nUse 'hz start' or 'systemctl start hazelcast' to start the Hazelcast
 %{_prefix}/lib/hazelcast/custom-lib
 %{_prefix}/lib/hazelcast/lib
 %{_prefix}/lib/hazelcast/licenses
+%{_prefix}/lib/hazelcast/release_notes.txt
 %config(noreplace) %{_prefix}/lib/hazelcast/config/*.xml
 %config(noreplace) %{_prefix}/lib/hazelcast/config/*.yaml
 %config(noreplace) %{_prefix}/lib/hazelcast/config/*.options


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-packaging/pull/250

In https://github.com/hazelcast/hazelcast-mono/pull/3381, `release_notes.txt` was added to the distribution `ZIP` ([further discussion](https://github.com/hazelcast/hazelcast-mono/pull/3657)). Because the `spec` was unaware, an error was thrown:
```
Installed (but unpackaged) file(s) found: /usr/lib/hazelcast/release_notes.txt
```

Updated to explicitly install.

Fixes: [DI-358](https://hazelcast.atlassian.net/browse/DI-358)

[DI-358]: https://hazelcast.atlassian.net/browse/DI-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ