### PR TITLE
Fix `check-hazelcast-health.sh`

### DIFF
--- a/check-hazelcast-health.sh
+++ b/check-hazelcast-health.sh
@@ -3,7 +3,6 @@
 set -o errexit ${RUNNER_DEBUG:+-x}
 
 pushd hazelcast-docker
-  # shellcheck source=../hazelcast-docker/.github/scripts/abstract-simple-smoke-test.sh
   . .github/scripts/abstract-simple-smoke-test.sh
 popd
 

--- a/check-hazelcast-health.sh
+++ b/check-hazelcast-health.sh
@@ -2,8 +2,10 @@
 
 set -o errexit ${RUNNER_DEBUG:+-x}
 
-# shellcheck source=../hazelcast-docker/.github/scripts/abstract-simple-smoke-test.sh
-. hazelcast-docker/.github/scripts/abstract-simple-smoke-test.sh
+pushd hazelcast-docker
+  # shellcheck source=../hazelcast-docker/.github/scripts/abstract-simple-smoke-test.sh
+  . .github/scripts/abstract-simple-smoke-test.sh
+popd
 
 function get_hz_logs() {
     cat hz.log


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-packaging/pull/251, `check-hazelcast-health.sh` [was broken](https://github.com/hazelcast/hazelcast-packaging/actions/runs/12227856565):
> hazelcast-docker/.github/scripts/abstract-simple-smoke-test.sh: line 6: .github/scripts/logging.functions.sh: No such file or directory

We checkout `hazelcast-docker` to a subdirectory, but the convention is all our scripts to `source` from the relative path.