### PR TITLE
Increase publishing repository metadata calculation timeout [5.5.z]

### DIFF
--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           source common.sh
 
-          curl --fail-with-body --retry 3 --retry-delay 10 -H "Authorization: Bearer ${{ env.JFROG_TOKEN }}" \
+          curl --fail-with-body --retry 10 --retry-max-time 240 -H "Authorization: Bearer ${{ env.JFROG_TOKEN }}" \
             -X POST "https://repository.hazelcast.com/api/deb/reindex/${DEBIAN_REPO}"
 
       - name: Install Hazelcast from deb

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -73,7 +73,7 @@ jobs:
           ls -lah
           source ./common.sh
 
-          curl --fail-with-body --retry 3 --retry-delay 10 -H "Authorization: Bearer ${{ env.JFROG_TOKEN }}" \
+          curl --fail-with-body --retry 10 --retry-max-time 240 -H "Authorization: Bearer ${{ env.JFROG_TOKEN }}" \
             -X POST "https://repository.hazelcast.com/api/yum/${RPM_REPO}"
 
       - name: Install Hazelcast from rpm


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast-packaging/pull/259

Following investigation of a [release failure](https://github.com/hazelcast/hazelcast-packaging/actions/runs/13414846262/attempts/1), [one suggestion](https://hazelcast.atlassian.net/browse/DI-431?focusedCommentId=109867) was to space the retries to give the server more opportunities to respond.