### PR TITLE
Migrate `publish-packages` Action trigger to GitHub Actions [DI-475]

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -6,6 +6,8 @@ on:
       - master
     tags:
       - 'v*'
+  schedule:
+    - cron: '0 2 * * *' # 2AM Nightly
   pull_request:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This job is triggered by a [scheduled Jenkins job](https://jenkins.hazelcast.com/job/Hazelcast-packaging-master-snapshot-trigger/). This Jenkins job recently failed due to some dependency issue, but instead of fixing it, it's easier to refactor and remove it.

The job is triggered with `HZ_VERSION` derived from the `version` declared in the `hazelcast-mono` `pom`. This is redundant, as the job already the same value ([automatically maintained](https://github.com/hazelcast/hazelcast-packaging/commit/0fd1a9a1b5bcbd2d5d25663f6335cd43b7a25abd)) in it's own `pom`: https://github.com/hazelcast/hazelcast-packaging/blob/b86bcf775fdf5bf49168734b2e1aab2449c2b182/pom.xml#L9

And the job will use this version if not explicitly provided: https://github.com/hazelcast/hazelcast-packaging/blob/b86bcf775fdf5bf49168734b2e1aab2449c2b182/.github/workflows/publish-packages.yml#L74-L80

As such we can simply trigger this job on a schedule via GitHub Actions rather than triggering it externally.

Fixes: [DI-475](https://hazelcast.atlassian.net/browse/DI-475)

Post-merge actions:
- [ ] Disable the Jenkins job

[DI-475]: https://hazelcast.atlassian.net/browse/DI-475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ