### PR TITLE
Refactor how `assert.sh` is downloaded for tests

### DIFF
--- a/.github/workflows/build.functions_tests.sh
+++ b/.github/workflows/build.functions_tests.sh
@@ -4,10 +4,7 @@ set -eu
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-assert_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)
-# shellcheck source=/dev/null
-. <(echo "${assert_script_content}")
-. "$SCRIPT_DIR"/build.functions.sh
+source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 TESTS_RESULT=0
 

--- a/common_tests.sh
+++ b/common_tests.sh
@@ -5,10 +5,7 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 export USE_TEST_REPO=true
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-assert_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)
-# shellcheck source=/dev/null
-. <(echo "${assert_script_content}")
-. "$SCRIPT_DIR"/common.sh
+source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 TESTS_RESULT=0
 

--- a/packages/brew/brew_functions_tests.sh
+++ b/packages/brew/brew_functions_tests.sh
@@ -3,10 +3,7 @@
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-assert_script_content=$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)
-# shellcheck source=/dev/null
-. <(echo "${assert_script_content}")
-. "$SCRIPT_DIR"/brew_functions.sh
+source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 TESTS_RESULT=0
 


### PR DESCRIPTION
We can simplify as discussed [here](https://github.com/hazelcast/docker-actions/pull/1#discussion_r2149451062).