### PR TITLE
Remove redundant authentication from `publish-deb-package.yml`

### DIFF
--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -83,7 +83,6 @@ jobs:
           apt-get install -y --no-upgrade wget gpg coreutils \
             && wget \
               https://repository.hazelcast.com/api/gpg/key/public \
-              --header "Authorization: Bearer ${{ env.JFROG_TOKEN }}" \
               --output-document - \
               --quiet \
               | gpg --dearmor \


### PR DESCRIPTION
https://repository.hazelcast.com/api/gpg/key/public is (as the name says) public, no authorization is required - added in error in https://github.com/hazelcast/hazelcast-packaging/pull/214