### PR TITLE
Migrate RPM repositories to new GPG keys [DI-598]

### DIFF
--- a/repos/README.md
+++ b/repos/README.md
@@ -9,10 +9,10 @@ Upload the file to artifactory:
 - TEST environment
 ```shell
 export REPO=stable; # beta,snapshot,stable
-curl -H "Authorization: Bearer ${JFROG_TOKEN}" -Thazelcast-rpm-${REPO}.repo -X PUT "https://repository.hazelcast.com/rpm-test-local/${REPO}/"
+curl -H "Authorization: Bearer ${JFROG_TOKEN}" --upload-file hazelcast-rpm-${REPO}.repo -X PUT "https://repository.hazelcast.com/rpm-test-local/${REPO}/"
 ```
 - PROD environment
 ```shell
 export REPO=stable; # beta,snapshot,stable
-curl -H "Authorization: Bearer ${JFROG_TOKEN}" -Thazelcast-rpm-${REPO}.repo -X PUT "https://repository.hazelcast.com/rpm-local/${REPO}/"
+curl -H "Authorization: Bearer ${JFROG_TOKEN}" --upload-file hazelcast-rpm-${REPO}.repo -X PUT "https://repository.hazelcast.com/rpm-local/${REPO}/"
 ```

--- a/repos/README.md
+++ b/repos/README.md
@@ -9,7 +9,7 @@ Upload the file to artifactory:
 - TEST environment
 ```shell
 export REPO=stable; # beta,snapshot,stable
-curl -H "Authorization: Bearer ${JFROG_TOKEN}"  -Thazelcast-rpm-${REPO}.repo -X PUT "https://repository.hazelcast.com/rpm-test-local/${REPO}/"
+curl -H "Authorization: Bearer ${JFROG_TOKEN}" -Thazelcast-rpm-${REPO}.repo -X PUT "https://repository.hazelcast.com/rpm-test-local/${REPO}/"
 ```
 - PROD environment
 ```shell

--- a/repos/README.md
+++ b/repos/README.md
@@ -6,7 +6,13 @@ structure).
 
 Upload the file to artifactory:
 
+- TEST environment
+```shell
+export REPO=stable; # beta,snapshot,stable
+curl -H "Authorization: Bearer ${JFROG_TOKEN}"  -Thazelcast-rpm-${REPO}.repo -X PUT "https://repository.hazelcast.com/rpm-test-local/${REPO}/"
 ```
-curl -H "Authorization: Bearer ${JFROG_TOKEN}" -Thazelcast-rpm-stable.repo -X PUT "https://repository.hazelcast.com/rpm-local/stable/"
+- PROD environment
+```shell
+export REPO=stable; # beta,snapshot,stable
+curl -H "Authorization: Bearer ${JFROG_TOKEN}"  -Thazelcast-rpm-${REPO}.repo -X PUT "https://repository.hazelcast.com/rpm-local/${REPO}/"
 ```
-

--- a/repos/README.md
+++ b/repos/README.md
@@ -14,5 +14,5 @@ curl -H "Authorization: Bearer ${JFROG_TOKEN}" -Thazelcast-rpm-${REPO}.repo -X P
 - PROD environment
 ```shell
 export REPO=stable; # beta,snapshot,stable
-curl -H "Authorization: Bearer ${JFROG_TOKEN}"  -Thazelcast-rpm-${REPO}.repo -X PUT "https://repository.hazelcast.com/rpm-local/${REPO}/"
+curl -H "Authorization: Bearer ${JFROG_TOKEN}" -Thazelcast-rpm-${REPO}.repo -X PUT "https://repository.hazelcast.com/rpm-local/${REPO}/"
 ```

--- a/repos/prod/hazelcast-rpm-beta.repo
+++ b/repos/prod/hazelcast-rpm-beta.repo
@@ -3,5 +3,5 @@ name=Hazelcast RPM Beta Repository
 baseurl=https://repository.hazelcast.com/rpm/beta
 enabled=1
 gpgcheck=1
-gpgkey=https://repository.hazelcast.com/rpm/beta/repodata/repomd.xml.key
+gpgkey=https://repository.hazelcast.com/api/security/keypair/public/repositories/rpm https://repository.hazelcast.com/api/security/keypair/gpg-key-2011/public
 repo_gpgcheck=1

--- a/repos/prod/hazelcast-rpm-snapshot.repo
+++ b/repos/prod/hazelcast-rpm-snapshot.repo
@@ -3,5 +3,5 @@ name=Hazelcast RPM Snapshot Repository
 baseurl=https://repository.hazelcast.com/rpm/snapshot
 enabled=1
 gpgcheck=1
-gpgkey=https://repository.hazelcast.com/rpm/snapshot/repodata/repomd.xml.key
+gpgkey=https://repository.hazelcast.com/api/security/keypair/public/repositories/rpm https://repository.hazelcast.com/api/security/keypair/gpg-key-2011/public
 repo_gpgcheck=1

--- a/repos/prod/hazelcast-rpm-stable.repo
+++ b/repos/prod/hazelcast-rpm-stable.repo
@@ -3,5 +3,5 @@ name=Hazelcast RPM Stable Repository
 baseurl=https://repository.hazelcast.com/rpm/stable
 enabled=1
 gpgcheck=1
-gpgkey=https://repository.hazelcast.com/rpm/stable/repodata/repomd.xml.key
+gpgkey=https://repository.hazelcast.com/api/security/keypair/public/repositories/rpm https://repository.hazelcast.com/api/security/keypair/gpg-key-2011/public
 repo_gpgcheck=1

--- a/repos/test/hazelcast-rpm-beta.repo
+++ b/repos/test/hazelcast-rpm-beta.repo
@@ -3,5 +3,5 @@ name=Hazelcast RPM Beta Repository
 baseurl=https://repository.hazelcast.com/rpm-test-local/beta
 enabled=1
 gpgcheck=1
-gpgkey=https://repository.hazelcast.com/rpm-test-local/beta/repodata/repomd.xml.key
+gpgkey=https://repository.hazelcast.com/api/security/keypair/public/repositories/rpm-test-local https://repository.hazelcast.com/api/security/keypair/gpg-key-2011/public
 repo_gpgcheck=1

--- a/repos/test/hazelcast-rpm-snapshot.repo
+++ b/repos/test/hazelcast-rpm-snapshot.repo
@@ -3,5 +3,5 @@ name=Hazelcast RPM Snapshot Repository
 baseurl=https://repository.hazelcast.com/rpm-test-local/snapshot
 enabled=1
 gpgcheck=1
-gpgkey=https://repository.hazelcast.com/rpm-test-local/snapshot/repodata/repomd.xml.key
+gpgkey=https://repository.hazelcast.com/api/security/keypair/public/repositories/rpm-test-local https://repository.hazelcast.com/api/security/keypair/gpg-key-2011/public
 repo_gpgcheck=1

--- a/repos/test/hazelcast-rpm-stable.repo
+++ b/repos/test/hazelcast-rpm-stable.repo
@@ -3,5 +3,5 @@ name=Hazelcast RPM Stable Repository
 baseurl=https://repository.hazelcast.com/rpm-test-local/stable
 enabled=1
 gpgcheck=1
-gpgkey=https://repository.hazelcast.com/rpm-test-local/stable/repodata/repomd.xml.key
+gpgkey=https://repository.hazelcast.com/api/security/keypair/public/repositories/rpm-test-local https://repository.hazelcast.com/api/security/keypair/gpg-key-2011/public
 repo_gpgcheck=1


### PR DESCRIPTION
- Use official urls for repository keys https://repository.hazelcast.com/api/security/keypair/public/repositories/<REPO> 
- Add a legacy key (https://repository.hazelcast.com/api/security/keypair/gpg-key-2011/public) to enable verification and installation of the older RPM packages
- Improve README 

Not fixing [DI-598](https://hazelcast.atlassian.net/browse/DI-598) but it's related

[DI-598]: https://hazelcast.atlassian.net/browse/DI-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Test run (see two keys imported) : https://github.com/hazelcast/hazelcast-packaging/actions/runs/17099498381/job/48491972566

<img width="1030" height="697" alt="image" src="https://github.com/user-attachments/assets/6ef18ddc-9622-4ef7-bb25-b135cbf6024a" />

<img width="895" height="707" alt="image" src="https://github.com/user-attachments/assets/00864c4e-0ed3-49a1-a1af-569dbfd322b3" />
