### PR TITLE
Update Maven central URL

### DIFF
--- a/.github/workflows/build.functions.sh
+++ b/.github/workflows/build.functions.sh
@@ -42,7 +42,7 @@ function get_hz_dist_tar_gz() {
     if [[ "${hz_version}" == *"SNAPSHOT"* ]]; then
       url="https://${HZ_SNAPSHOT_INTERNAL_USERNAME}:${HZ_SNAPSHOT_INTERNAL_PASSWORD}@repository.hazelcast.com/snapshot-internal/com/hazelcast/hazelcast-distribution/${hz_version}/hazelcast-distribution-${hz_version}.$extension"
     else
-      url="https://repo1.maven.org/maven2/com/hazelcast/hazelcast-distribution/${hz_version}/hazelcast-distribution-${hz_version}.$extension"
+      url="https://repo.maven.apache.org/maven2/com/hazelcast/hazelcast-distribution/${hz_version}/hazelcast-distribution-${hz_version}.$extension"
     fi
   elif [[ "$distribution" == "hazelcast-enterprise" ]]; then
     local repository

--- a/.github/workflows/build.functions_tests.sh
+++ b/.github/workflows/build.functions_tests.sh
@@ -64,7 +64,7 @@ function assert_get_hz_dist_tar_gz {
 log_header "Tests for get_hz_dist_tar_gz"
 export HZ_SNAPSHOT_INTERNAL_USERNAME=dummy_user
 export HZ_SNAPSHOT_INTERNAL_PASSWORD=dummy_password
-assert_get_hz_dist_tar_gz 5.4.0 hazelcast https://repo1.maven.org/maven2/com/hazelcast/hazelcast-distribution/5.4.0/hazelcast-distribution-5.4.0.tar.gz
+assert_get_hz_dist_tar_gz 5.4.0 hazelcast https://repo.maven.apache.org/maven2/com/hazelcast/hazelcast-distribution/5.4.0/hazelcast-distribution-5.4.0.tar.gz
 assert_get_hz_dist_tar_gz 5.5.0-SNAPSHOT hazelcast https://dummy_user:dummy_password@repository.hazelcast.com/snapshot-internal/com/hazelcast/hazelcast-distribution/5.5.0-SNAPSHOT/hazelcast-distribution-5.5.0-SNAPSHOT.tar.gz
 
 assert_get_hz_dist_tar_gz 5.4.0 hazelcast-enterprise https://repository.hazelcast.com/release/com/hazelcast/hazelcast-enterprise-distribution/5.4.0/hazelcast-enterprise-distribution-5.4.0.tar.gz
@@ -80,6 +80,6 @@ function assert_url_contains_password {
 }
 
 assert_url_contains_password "https://dummy_user:dummy_password@repository.hazelcast.com/snapshot-internal/com/hazelcast/hazelcast-distribution/5.5.0-SNAPSHOT/hazelcast-distribution-5.5.0-SNAPSHOT.tar.gz" "dummy_password" "yes"
-assert_url_contains_password "https://repo1.maven.org/maven2/com/hazelcast/hazelcast-distribution/5.4.0/hazelcast-distribution-5.4.0.tar.gz" "dummy_password" "no"
+assert_url_contains_password "https://repo.maven.apache.org/maven2/com/hazelcast/hazelcast-distribution/5.4.0/hazelcast-distribution-5.4.0.tar.gz" "dummy_password" "no"
 
 assert_eq 0 "$TESTS_RESULT" "ALL tests should pass"


### PR DESCRIPTION
In https://issues.apache.org/jira/browse/MNG-5151 Maven updated the default URL from `repo1.maven.org/maven2` -> `repo.maven.apache.org/maven2`.

Updated references to suit.