### PR TITLE
Migrate packaging trigger from schedule to post-`SNAPSHOT` build [DI-655]

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -6,8 +6,6 @@ on:
       - master
     tags:
       - 'v*'
-  schedule:
-    - cron: '0 2 * * *' # 2AM Nightly
   pull_request:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
We should trigger the job when there's a new `SNAPSHOT` to consume (i.e. after build), not on a schedule regardless.

Fixes: [DI-655](https://hazelcast.atlassian.net/browse/DI-655)