### PR TITLE
Remove `default` options from `required` inputs

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -17,7 +17,6 @@ on:
       PACKAGE_TYPES:
         description: 'Packages to build'
         required: true
-        default: 'all'
         type: choice
         options:
         - all
@@ -27,7 +26,6 @@ on:
       RELEASE_TYPE:
         description: 'Which editions should be built'
         required: true
-        default: 'EE'
         type: choice
         options:
           - ALL
@@ -36,7 +34,6 @@ on:
       ENVIRONMENT:
         description: 'Environment to use'
         required: true
-        default: 'live'
         type: choice
         options:
           - test


### PR DESCRIPTION
If an `input` is `required`, specifying a `default` value makes no sense.