### PR TITLE
Replace `sed` with `envsubst`

### DIFF
--- a/build-hazelcast-homebrew-package.sh
+++ b/build-hazelcast-homebrew-package.sh
@@ -41,20 +41,14 @@ ASSET_SHASUM=$(sha256sum "${HZ_DISTRIBUTION_FILE}" | cut -d ' ' -f 1)
 TEMPLATE_FILE="$(pwd)/packages/brew/hazelcast-template.rb"
 cd homebrew-hz || exit 1
 
-function updateClassName {
-  class=$1
-  file=$2
-  sed -i "s+class HazelcastAT5X <\(.*$\)+class $class <\1+g" "$file"
-}
-
 function generateFormula {
   class=$1
   file=$2
   echo "Generating $file formula"
-  cp "$TEMPLATE_FILE" "$file"
-  updateClassName "$class" "$file"
-  sed -i "s+url.*$+url \"${HZ_PACKAGE_URL}\"+g" "$file"
-  sed -i "s+sha256.*$+sha256 \"${ASSET_SHASUM}\"+g" "$file"
+  export class
+  export HZ_PACKAGE_URL
+  export ASSET_SHASUM
+  envsubst <"${TEMPLATE_FILE}" >"${file}"
   all_hz_versions=({hazelcast.rb,hazelcast?[0-9]*\.rb,hazelcast-enterprise*\.rb})
   for version in "${all_hz_versions[@]}"
   do

--- a/packages/brew/hazelcast-template.rb
+++ b/packages/brew/hazelcast-template.rb
@@ -1,8 +1,8 @@
-class HazelcastAT5X < Formula
+class ${class} < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
-    url "https://github.com/hazelcast/hazelcast-command-line/releases/download/v5.2021.07.1/hazelcast-5.0-BETA-1.tar.gz"
-    sha256 "f108d22a1aec61bbd637f89ff522af7d9861ef13afcfad24a5095127f04f091d"
+    url "${HZ_PACKAGE_URL}"
+    sha256 "${ASSET_SHASUM}"
 
     depends_on "openjdk@21" => :recommended
 


### PR DESCRIPTION
We use `envsubst` elsewhere:
https://github.com/hazelcast/hazelcast-packaging/blob/a4130c384fcf4f1ef114e76ca099336e55829567/build-hazelcast-rpm-package.sh#L40-L42

But not for homebrew:
https://github.com/hazelcast/hazelcast-packaging/blob/a4130c384fcf4f1ef114e76ca099336e55829567/build-hazelcast-homebrew-package.sh#L54-L56

This makes populating template files neater.