### PR TITLE
Remove unused env vars from `promote-brew-package`

### DIFF
--- a/.github/workflows/promote-brew-package.yml
+++ b/.github/workflows/promote-brew-package.yml
@@ -72,5 +72,3 @@ jobs:
             fi
         env:
           GH_TOKEN: ${{ env.GITHUB_DEVOPSHAZELCAST_SECRET }}
-          HZ_VERSION: ${{ inputs.HZ_VERSION }}
-          HZ_DISTRIBUTION: ${{ inputs.HZ_DISTRIBUTION }}


### PR DESCRIPTION
Were added before a centralised `get-homebrew-pr-title` was introduced, redundant.