### PR TITLE
Don't build `hazelcast-packaging` on `push`

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -2,9 +2,6 @@ name: Publish Hazelcast OS & EE packages
 run-name: ${{ github.workflow }} (`${{ inputs.VERSION }}`@${{ inputs.ENVIRONMENT }})
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
We currently trigger `publish-packages` after every `push` - but we don't do this in `hazelcast-docker`.

Packaging is already being triggered after (nightly) `SNAPSHOT`s so this is redundant.