### PR TITLE
Split PR workflow from publish

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -18,6 +18,6 @@ jobs:
     uses: ./.github/workflows/publish-packages.yml
     with:
       VERSION: ${{ github.ref }}
-      RELEASE_TYPE: all
+      RELEASE_TYPE: ALL
       ENVIRONMENT: test
     secrets: inherit

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,23 @@
+name: Build PR
+
+on:
+  pull_request:
+
+jobs:
+  test-scripts:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout hazelcast-packaging repo
+        uses: actions/checkout@v6
+
+      - name: Test scripts
+        run: |
+          ./test_scripts.sh
+
+  publish-packages:
+    uses: ./.github/workflows/publish-packages.yml
+    with:
+      VERSION: ${{ github.ref }}
+      RELEASE_TYPE: all
+      ENVIRONMENT: test
+    secrets: inherit

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -50,9 +50,6 @@ on:
         required: true
         type: string
 
-env:
-  EVENT_NAME: ${{ github.event_name }}
-
 concurrency:
   group: '${{ github.workflow }}-${{ github.base_ref || github.ref_name}}'
 
@@ -60,7 +57,6 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     env:
-      RELEASE_TYPE: ${{ inputs.RELEASE_TYPE || 'EE' }}
       PACKAGE_TYPES: ${{ inputs.PACKAGE_TYPES || 'all' }}
     outputs:
       hz_version: ${{ steps.hz_version_step.outputs.hz_version }}
@@ -125,9 +121,7 @@ jobs:
           echo "| Name | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| HZ_VERSION | ${{ steps.hz_version_step.outputs.hz_version }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| PACKAGE_TYPES | ${PACKAGE_TYPES} |" >> $GITHUB_STEP_SUMMARY
-          echo "| RELEASE_TYPE | ${RELEASE_TYPE} |" >> $GITHUB_STEP_SUMMARY
-          echo "| ENVIRONMENT | ${{ steps.environment.outputs.ENVIRONMENT }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| PACKAGE_TYPES | ${PACKAGE_TYPES} |" >> $GITHUB_STEP_SUMMARY          echo "| ENVIRONMENT | ${{ steps.environment.outputs.ENVIRONMENT }} |" >> $GITHUB_STEP_SUMMARY
           echo "| RELEASE_CHANNEL | ${{ steps.release_channel.outputs.channel }} |" >> $GITHUB_STEP_SUMMARY
           echo "| JAVA_VERSION | ${{ steps.jdks.outputs.default-jdk }} |" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -2,10 +2,6 @@ name: Publish Hazelcast OS & EE packages
 run-name: ${{ github.workflow }} (`${{ inputs.VERSION }}`@${{ inputs.ENVIRONMENT }})
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
   workflow_dispatch:
     inputs:
       VERSION:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -53,11 +53,11 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     env:
-      PACKAGE_TYPES: ${{ inputs.PACKAGE_TYPES || 'all' }}
+      PACKAGE_TYPES: ${{ inputs.PACKAGE_TYPES }}
     outputs:
       hz_version: ${{ steps.hz_version_step.outputs.hz_version }}
-      should_build_oss: ${{ steps.resolve-editions.outputs.should_build_oss == 'true' || github.event_name == 'pull_request' }}
-      should_build_ee: ${{ steps.resolve-editions.outputs.should_build_ee == 'true' || github.event_name == 'pull_request'}}
+      should_build_oss: ${{ steps.resolve-editions.outputs.should_build_oss == 'true' }}
+      should_build_ee: ${{ steps.resolve-editions.outputs.should_build_ee == 'true'}}
       should_build_deb: ${{ env.PACKAGE_TYPES == 'all' || env.PACKAGE_TYPES == 'deb' }}
       should_build_rpm: ${{ env.PACKAGE_TYPES == 'all' || env.PACKAGE_TYPES == 'rpm' }}
       should_build_homebrew: ${{ env.PACKAGE_TYPES == 'all' || env.PACKAGE_TYPES == 'homebrew' }}
@@ -76,10 +76,6 @@ jobs:
           sparse-checkout: "**/pom.xml"
           sparse-checkout-cone-mode: false
 
-      - name: Test scripts
-        run: |
-          ./test_scripts.sh
-
       - name: Set HZ_VERSION
         id: hz_version_step
         run: |
@@ -93,7 +89,7 @@ jobs:
       - name: Calculate the environment
         id: environment
         run: |
-          ENVIRONMENT=${{ (env.EVENT_NAME == 'pull_request' && 'test') || inputs.ENVIRONMENT || 'live' }}
+          ENVIRONMENT=${{ inputs.ENVIRONMENT || 'live' }}
           echo "ENVIRONMENT=${ENVIRONMENT}" >> $GITHUB_OUTPUT
 
       - name: Get supported JDKs

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -53,7 +53,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     env:
-      PACKAGE_TYPES: ${{ inputs.PACKAGE_TYPES }}
+      PACKAGE_TYPES: ${{ inputs.PACKAGE_TYPES || 'all' }}
     outputs:
       hz_version: ${{ steps.hz_version_step.outputs.hz_version }}
       should_build_oss: ${{ steps.resolve-editions.outputs.should_build_oss == 'true' }}


### PR DESCRIPTION
Because the `publish-packages` workflow is used for both production builds _and_ PR tests, it always run `test-scripts` and is generally a bit confused.

We should split the PR specific testing into a specific action and that way the `publish-packages` action doesn't need to consider PR-specific input checking.

Post-merge actions:
- [x] update branch protection