### PR TITLE
Avoid Cloudfront timeout issues

### DIFF
--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Calculate Debian Repository Metadata
         run: |
           curl --fail-with-body --retry 10 --retry-max-time 240 -H "Authorization: Bearer ${JFROG_TOKEN}" \
-            -X POST "https://repository.hazelcast.com/api/deb/reindex/${{ vars.DEBIAN_REPO }}"
+            -X POST "https://${{ steps.authenticate-jfrog-write-dev-account.outputs.url }}/artifactory/api/deb/reindex/${{ vars.DEBIAN_REPO }}"
         env:
           JFROG_TOKEN: ${{ steps.authenticate-jfrog-write-dev-account.outputs.token }}
 

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Calculate YUM Repository Metadata
         run: |
           curl --fail-with-body --retry 10 --retry-max-time 240 -H "Authorization: Bearer ${JFROG_TOKEN}" \
-            -X POST "https://repository.hazelcast.com/api/yum/${{ vars.RPM_REPO }}"
+            -X POST "https://${{ steps.authenticate-jfrog-write-dev-account.outputs.url }}/artifactory/api/yum/${{ vars.RPM_REPO }}"
         env:
           JFROG_TOKEN: ${{ steps.authenticate-jfrog-write-dev-account.outputs.token }}
 


### PR DESCRIPTION
We proxy JFrog repo requests via Cloudfront, but the configuration has a 1 minute timeout on requests.
JFrog requests can take longer than that, and while the Cloudfront timeout is configurable, there's an [upper bound of 2 minutes)[https://repost.aws/knowledge-center/cloudfront-custom-origin-response].

This timeout causes [build failures](https://github.com/hazelcast/hazelcast-packaging/actions/runs/25731100470/job/75556444196#step:9:350) where the requests are non-obviously truncated after 1 minute.

We can workaround this issue by circumventing the proxy altogether - e.g with this change, [we can await completion of a request that took 2 minutes](https://github.com/hazelcast/hazelcast-packaging/actions/runs/25753141899/job/75634594168#step:9:162).

I've _only_ updated the problematic API `reindex` request as generally we _want_ our CI pipeline to use public-facing infrastructure to validate end-user accessibility... _where possible_.