### PR TITLE
Improve GitHub Actions job names

### DIFF
--- a/.github/workflows/publish-brew-package.yml
+++ b/.github/workflows/publish-brew-package.yml
@@ -31,6 +31,7 @@ concurrency:
 
 jobs:
   homebrew:
+    name: Homebrew (`${{ inputs.HZ_DISTRIBUTION }}`)
     environment: ${{ inputs.ENVIRONMENT }}
     runs-on: macos-latest
     permissions:

--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -28,6 +28,7 @@ concurrency:
 
 jobs:
   deb:
+    name: Deb (`${{ inputs.HZ_DISTRIBUTION }}`)
     environment: ${{ inputs.ENVIRONMENT }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -28,6 +28,7 @@ concurrency:
 
 jobs:
   rpm:
+    name: RPM (`${{ inputs.HZ_DISTRIBUTION }}`)
     environment: ${{ inputs.ENVIRONMENT }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
This isn't very helpful:
<img width="295" height="282" alt="image" src="https://github.com/user-attachments/assets/cc168f0b-cf28-4abc-842c-003955cd5b1d" />

Updated to be unique:
<img width="288" height="308" alt="image" src="https://github.com/user-attachments/assets/98d0b4d9-c7fb-48c2-8742-69239b0b9e51" />
