### PR TITLE
Remove `github.job` from `concurrency` key

### DIFF
--- a/.github/workflows/publish-brew-package.yml
+++ b/.github/workflows/publish-brew-package.yml
@@ -27,7 +27,7 @@ on:
         value: ${{ jobs.homebrew.outputs.pull-request-operation }}
 
 concurrency:
-  group: 'brew-${{ github.job }}-${{ inputs.HZ_VERSION }}-${{ inputs.HZ_DISTRIBUTION}}'
+  group: 'brew-${{ inputs.HZ_VERSION }}-${{ inputs.HZ_DISTRIBUTION}}'
 
 jobs:
   homebrew:

--- a/.github/workflows/publish-brew-package.yml
+++ b/.github/workflows/publish-brew-package.yml
@@ -27,7 +27,7 @@ on:
         value: ${{ jobs.homebrew.outputs.pull-request-operation }}
 
 concurrency:
-  group: 'brew-${{ inputs.HZ_VERSION }}-${{ inputs.HZ_DISTRIBUTION}}'
+  group: 'brew-${{ inputs.HZ_VERSION }}-${{ inputs.HZ_DISTRIBUTION }}'
 
 jobs:
   homebrew:

--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -24,7 +24,7 @@ on:
         type: string
 
 concurrency:
-  group: 'deb-${{ inputs.HZ_VERSION }}-${{ inputs.HZ_DISTRIBUTION}}'
+  group: 'deb-${{ inputs.HZ_VERSION }}-${{ inputs.HZ_DISTRIBUTION }}'
 
 jobs:
   deb:

--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -24,7 +24,7 @@ on:
         type: string
 
 concurrency:
-  group: 'deb-${{ github.job }}-${{ inputs.HZ_VERSION }}-${{ inputs.HZ_DISTRIBUTION}}'
+  group: 'deb-${{ inputs.HZ_VERSION }}-${{ inputs.HZ_DISTRIBUTION}}'
 
 jobs:
   deb:

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -24,7 +24,7 @@ on:
         type: string
 
 concurrency:
-  group: 'rpm-${{ inputs.HZ_VERSION }}-${{ inputs.HZ_DISTRIBUTION}}'
+  group: 'rpm-${{ inputs.HZ_VERSION }}-${{ inputs.HZ_DISTRIBUTION }}'
 
 jobs:
   rpm:

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -24,7 +24,7 @@ on:
         type: string
 
 concurrency:
-  group: 'rpm-${{ github.job }}-${{ inputs.HZ_VERSION }}-${{ inputs.HZ_DISTRIBUTION}}'
+  group: 'rpm-${{ inputs.HZ_VERSION }}-${{ inputs.HZ_DISTRIBUTION}}'
 
 jobs:
   rpm:


### PR DESCRIPTION
As per [the docs](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context), `github.job` is `null` when queried outside of a job.

Therefore it's always null - pointless, removed.