### PR TITLE
Migrate tagging out of release pipeline [DI-838]

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -25,9 +25,12 @@ on:
         required: false
 
 jobs:
-  log-distinct-id:
-    runs-on: ubuntu-slim
-    if: inputs.distinct_id != ''
+  update-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ inputs.VERSION }}
     steps:
         # https://github.com/Codex-/return-dispatch#receiving-repository-action
       - name: Logging distinct ID (${{ inputs.distinct_id }})
@@ -35,7 +38,27 @@ jobs:
         env:
           DISTINCT_ID: ${{ inputs.distinct_id }}
 
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.VERSION }}
+
+      - name: Update `SNAPSHOT` to release version
+        run: |
+          mvn \
+            versions:set \
+            -DgenerateBackupPoms=false \
+            -DnewVersion=${VERSION}
+
+      - name: Commit
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+          git commit --all --message "Upgrade version to \`${VERSION}\`"
+          git push
+
   package:
+    needs: update-version
     uses: ./.github/workflows/publish-packages.yml
     with:
       VERSION: ${{ inputs.VERSION }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -46,6 +46,9 @@ jobs:
         run: |
           mvn \
             versions:set \
+            --batch-mode \
+            --no-transfer-progress \
+            --quiet \
             -DgenerateBackupPoms=false \
             -DnewVersion=${VERSION}
 

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -26,6 +26,8 @@ on:
 jobs:
   prepare:
     runs-on: ubuntu-slim
+    permissions:
+      contents: write
     outputs:
       distribution-types: ${{ steps.distribution-type-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -56,6 +56,11 @@ jobs:
           json="[$(IFS=,; echo "${entries[*]}")]"
           echo "matrix=$json" >> "${GITHUB_OUTPUT}"
 
+      - uses: hazelcast/docker-actions/create-tag@master
+        with:
+          TOKEN: ${{ github.token }}
+          BRANCH: ${{ inputs.VERSION }}
+
   promote:
     needs: prepare
     uses: ./.github/workflows/promote-brew-package.yml


### PR DESCRIPTION
Based off existing implementation in `hazelcast-docker`.

Example sandbox executions:
- [`package` (update version)](https://github.com/hz-devops-test/hazelcast-packaging/actions/runs/29090187906)
- [`promote` (create tag)](https://github.com/hz-devops-test/hazelcast-packaging/actions/runs/29090220018/job/86353519618)
- [resultant tag](https://github.com/hz-devops-test/hazelcast-packaging/releases/tag/v5.6.2)

Fixes: [DI-838](https://hazelcast.atlassian.net/browse/DI-838)

[DI-838]: https://hazelcast.atlassian.net/browse/DI-838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ