### PR TITLE
Interact with JFrog via `jf` CLI instead of `curl`

### DIFF
--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -42,7 +42,8 @@ jobs:
       HZ_VERSION: ${{ inputs.HZ_VERSION }}
       PACKAGE_VERSION: ${{ inputs.PACKAGE_VERSION || inputs.HZ_VERSION }}
       HZ_DISTRIBUTION: ${{ inputs.HZ_DISTRIBUTION }}
-      DEBIAN_REPO_BASE_URL: https://repository.hazelcast.com/${{ vars.DEBIAN_REPO }}
+      REPO_URL: https://repository.hazelcast.com
+      DEBIAN_REPO: ${{ vars.DEBIAN_REPO }}
 
     steps:
       - name: Checkout hazelcast-packaging repo
@@ -80,12 +81,11 @@ jobs:
           ./build-hazelcast-deb-package.sh
         env:
           JAVA_VERSION: ${{ inputs.JAVA_VERSION }}
-          JFROG_TOKEN: ${{ steps.authenticate-jfrog-write-dev-account.outputs.token }}
 
       - name: Calculate Debian Repository Metadata
         run: |
-          jf rt curl --fail-with-body --retry 10 --retry-max-time 240 \
-            -X POST "api/deb/reindex/${{ vars.DEBIAN_REPO }}"
+          # https://docs.jfrog.com/artifactory/reference/calculatedebianrepositorymetadata
+          jf api --method POST "/artifactory/api/deb/reindex/${DEBIAN_REPO}"
 
       - name: Install Hazelcast from deb
         env:
@@ -97,7 +97,7 @@ jobs:
 
           # Setup authentication file to access private repo
           sudo bash -c "cat >/etc/apt/auth.conf.d/hazelcast.conf <<EOF
-            machine $(echo ${DEBIAN_REPO_BASE_URL} | sed -E 's#https?://([^/]+).*#\1#')
+            machine $(echo https://repository.hazelcast.com/${DEBIAN_REPO} | sed -E 's#https?://([^/]+).*#\1#')
             login ${JFROG_USER}
             password ${JFROG_TOKEN}
           EOF"
@@ -111,7 +111,7 @@ jobs:
               --quiet \
               | gpg --dearmor \
               | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null \
-            && echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] ${DEBIAN_REPO_BASE_URL} ${PACKAGE_REPO} main" | sudo tee -a /etc/apt/sources.list.d/hazelcast.list \
+            && echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/${DEBIAN_REPO} ${RELEASE_CHANNEL} main" | sudo tee -a /etc/apt/sources.list.d/hazelcast.list \
             && sudo apt-get update && sudo apt-get install -y ${HZ_DISTRIBUTION}=${HZ_VERSION}
           HAZELCAST_CONFIG="$(pwd)/config/integration-test-hazelcast.yaml" hz-start > hz.log 2>&1 &
 
@@ -127,11 +127,7 @@ jobs:
         if: ${{ inputs.ENVIRONMENT == 'test' && (success() || failure()) }}
         run: |
           source ./common.sh
-          curl -H "Authorization: Bearer ${JFROG_TOKEN}" \
-            -X DELETE \
-            "$DEBIAN_REPO_BASE_URL/${HZ_DISTRIBUTION}-${DEB_PACKAGE_VERSION}-all.deb"
-        env:          
-          JFROG_TOKEN: ${{ steps.authenticate-jfrog-write-dev-account.outputs.token }}
+          jf rt delete "${DEBIAN_REPO}/${HZ_DISTRIBUTION}-${DEB_PACKAGE_VERSION}-all.deb"
 
       - name: Store logs as artifact
         if: ${{ always() }}

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -38,7 +38,7 @@ jobs:
       HZ_VERSION: ${{ inputs.HZ_VERSION }}
       PACKAGE_VERSION: ${{ inputs.PACKAGE_VERSION || inputs.HZ_VERSION }}
       HZ_DISTRIBUTION: ${{ inputs.HZ_DISTRIBUTION }}
-      RPM_REPO_BASE_URL: https://repository.hazelcast.com/${{ vars.RPM_REPO }}
+      RPM_REPO: ${{ vars.RPM_REPO }}
     steps:
       - name: Checkout hazelcast-packaging repo
         uses: actions/checkout@v7
@@ -87,12 +87,11 @@ jobs:
           ./build-hazelcast-rpm-package.sh
         env:
           JAVA_VERSION: ${{ inputs.JAVA_VERSION }}
-          JFROG_TOKEN: ${{ steps.authenticate-jfrog-write-dev-account.outputs.token }}
 
       - name: Calculate YUM Repository Metadata
         run: |
-          jf rt curl --fail-with-body --retry 10 --retry-max-time 240 \
-            -X POST "api/yum/${{ vars.RPM_REPO }}"
+          # https://docs.jfrog.com/artifactory/reference/calculateyumrepositorymetadata
+          jf api --method POST "/artifactory/api/yum/${RPM_REPO}"
 
       - name: Install Hazelcast from rpm
         env:
@@ -104,11 +103,11 @@ jobs:
 
           # Bake authentication into the returned URLs
           wget \
-            ${RPM_REPO_BASE_URL}/${PACKAGE_REPO}/hazelcast-rpm-${PACKAGE_REPO}.repo \
+            https://repository.hazelcast.com/${RPM_REPO}/${RELEASE_CHANNEL}/hazelcast-rpm-${RELEASE_CHANNEL}.repo \
             --header "Authorization: Bearer ${JFROG_TOKEN}" \
             --output-document - | \
           sed "s#https://#https://${JFROG_USER}:${JFROG_TOKEN}@#g" > \
-          /etc/yum.repos.d/hazelcast-rpm-${PACKAGE_REPO}.repo
+          /etc/yum.repos.d/hazelcast-rpm-${RELEASE_CHANNEL}.repo
 
           yum install -y ${HZ_DISTRIBUTION}-${RPM_HZ_VERSION}
           HAZELCAST_CONFIG="$(pwd)/config/integration-test-hazelcast.yaml" hz-start > hz.log 2>&1 &
@@ -126,11 +125,7 @@ jobs:
         if: ${{ inputs.ENVIRONMENT == 'test' && (success() || failure()) }}
         run: |
           source ./common.sh
-          curl -H "Authorization: Bearer ${JFROG_TOKEN}" \
-            -X DELETE \
-            "$RPM_REPO_BASE_URL/${PACKAGE_REPO}/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm"
-        env:
-          JFROG_TOKEN: ${{ steps.authenticate-jfrog-write-dev-account.outputs.token }}
+          jf rt delete "${RPM_REPO}/${RELEASE_CHANNEL}/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm"
 
       - name: Store logs as artifact
         if: ${{ always() }}

--- a/build-hazelcast-deb-package.sh
+++ b/build-hazelcast-deb-package.sh
@@ -63,22 +63,7 @@ mv build/deb/hazelcast.deb "$DEB_FILE"
 
 echo "Publishing $DEB_FILE to jfrog"
 
-DEB_SHA256SUM=$(sha256sum $DEB_FILE | cut -d ' ' -f 1)
-DEB_SHA1SUM=$(sha1sum $DEB_FILE | cut -d ' ' -f 1)
-DEB_MD5SUM=$(md5sum $DEB_FILE | cut -d ' ' -f 1)
-
-PACKAGE_URL="$DEBIAN_REPO_BASE_URL/${DEB_FILE}"
-HTTP_STATUS=$(curl -o /dev/null --silent --head --write-out '%{http_code}' -H "Authorization: Bearer ${JFROG_TOKEN}" "$PACKAGE_URL")
-
-if [ "$HTTP_STATUS" -eq 200 ]; then
-  # Delete any package that exists - previous version of the same package
-  curl --fail-with-body -H "Authorization: Bearer ${JFROG_TOKEN}" \
-    -X DELETE \
-    "$PACKAGE_URL"
-fi
-
-curl --fail-with-body -H "Authorization: Bearer ${JFROG_TOKEN}" -H "X-Checksum-Deploy: false" -H "X-Checksum-Sha256: $DEB_SHA256SUM" \
-  -H "X-Checksum-Sha1: $DEB_SHA1SUM" -H "X-Checksum-MD5: $DEB_MD5SUM" \
-  -T"$DEB_FILE" \
-  -X PUT \
-  "$PACKAGE_URL;deb.distribution=${PACKAGE_REPO};deb.component=main;deb.component=${HZ_MINOR_VERSION};deb.architecture=all"
+jf rt upload \
+  --deb="${RELEASE_CHANNEL}/main,${HZ_MINOR_VERSION}/all" \
+  "${DEB_FILE}" \
+  "${DEBIAN_REPO}/${DEB_FILE}"

--- a/build-hazelcast-rpm-package.sh
+++ b/build-hazelcast-rpm-package.sh
@@ -70,26 +70,11 @@ SIGNING_KEY_KEYGRIP=$(get_gpg_key_data "${SIGNING_KEY_PRIVATE_KEY}" "grp")
 ${GPG_PRESET_PASSPHRASE} --passphrase "${SIGNING_KEY_PASSPHRASE}" --preset ${SIGNING_KEY_KEYGRIP}
 rpmbuild --define "_topdir $(realpath build/rpmbuild)" -bb build/rpmbuild/rpm/hazelcast.spec
 
+RPM_FILE="build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm"
+
 export GPG_TTY="" # to avoid 'warning: Could not set GPG_TTY to stdin: Inappropriate ioctl for device' for the next command
-rpm --define "_gpg_name ${SIGNING_KEY_UID}" --addsign build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm
+rpm --define "_gpg_name ${SIGNING_KEY_UID}" --addsign "${RPM_FILE}"
 
-RPM_SHA256SUM=$(sha256sum "build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm" | cut -d ' ' -f 1)
-RPM_SHA1SUM=$(sha1sum "build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm" | cut -d ' ' -f 1)
-RPM_MD5SUM=$(md5sum "build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm" | cut -d ' ' -f 1)
-
-
-PACKAGE_URL="$RPM_REPO_BASE_URL/${PACKAGE_REPO}/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm"
-HTTP_STATUS=$(curl -o /dev/null --silent --head --write-out '%{http_code}' -H "Authorization: Bearer ${JFROG_TOKEN}" "$PACKAGE_URL")
-
-if [ "$HTTP_STATUS" -eq 200 ]; then
-  # Delete any package that exists - previous version of the same package
-  curl --fail-with-body -H "Authorization: Bearer ${JFROG_TOKEN}" \
-    -X DELETE \
-    "$PACKAGE_URL"
-fi
-
-curl --fail-with-body -H "Authorization: Bearer ${JFROG_TOKEN}" -H "X-Checksum-Deploy: false" -H "X-Checksum-Sha256: $RPM_SHA256SUM" \
-  -H "X-Checksum-Sha1: $RPM_SHA1SUM" -H "X-Checksum-MD5: $RPM_MD5SUM" \
-  -T"build/rpmbuild/RPMS/noarch/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm" \
-  -X PUT \
-  "$PACKAGE_URL"
+jf rt upload \
+  "${RPM_FILE}" \
+  "${RPM_REPO}/${RELEASE_CHANNEL}/${HZ_DISTRIBUTION}-${RPM_PACKAGE_VERSION}.noarch.rpm"

--- a/common.sh
+++ b/common.sh
@@ -11,7 +11,6 @@ fi
 if [[ "$HZ_VERSION" == *"BETA"* ]]; then
   export RELEASE_CHANNEL=beta
 fi
-export PACKAGE_REPO=${RELEASE_CHANNEL}
 
 if [[ "$HZ_VERSION" == *"-"* ]]; then
   HZ_MINOR_VERSION="${HZ_VERSION}"

--- a/repos/README.md
+++ b/repos/README.md
@@ -9,15 +9,15 @@ Upload the file to artifactory:
 - `test` environment
 ```shell
 export REPO=stable; # beta,snapshot,stable
-curl -H "Authorization: Bearer ${JFROG_TOKEN}" --upload-file hazelcast-rpm-${REPO}.repo -X PUT "https://repository.hazelcast.com/rpm-test-local/${REPO}/"
+jf rt upload hazelcast-rpm-${REPO}.repo "rpm-test-local/${REPO}/"
 ```
 - `sandbox` environment
 ```shell
 export REPO=stable; # beta,snapshot,stable
-curl -H "Authorization: Bearer ${JFROG_TOKEN}" --upload-file hazelcast-rpm-${REPO}.repo -X PUT "https://repository.hazelcast.com/sandbox-rpm-prod/${REPO}/"
+jf rt upload hazelcast-rpm-${REPO}.repo "sandbox-rpm-prod/${REPO}/"
 ```
 - `live` environment
 ```shell
 export REPO=stable; # beta,snapshot,stable
-curl -H "Authorization: Bearer ${JFROG_TOKEN}" --upload-file hazelcast-rpm-${REPO}.repo -X PUT "https://repository.hazelcast.com/rpm-local/${REPO}/"
+jf rt upload hazelcast-rpm-${REPO}.repo "rpm-local/${REPO}/"
 ```


### PR DESCRIPTION
[JFrog offer a CLI](https://docs.jfrog.com/integrations/docs/jfrog-cli) which offers several benefits over interacting with the API using `curl`:
- inbuilt authentication - no need to keep passing tokens around
- no need to keep specifying the JFrog URL
- [faster uploads with threads](https://docs.jfrog.com/artifactory/docs/binaries-management-with-jfrog-artifactory#advanced-upload-and-download-capabilities)
- [intelligent support for overwriting without needing to query/delete first](https://docs.jfrog.com/artifactory/docs/binaries-management-with-jfrog-artifactory#checksum-based-optimization)#
- automatic checksum generation

Updated to replace `curl` interactions with `jf`.

Of note, in https://github.com/hazelcast/hazelcast-packaging/pull/360 we swapped a couple of usages from `curl` to `jf rt curl` - but [this is actually deprecated](https://docs.jfrog.com/integrations/docs/curl-integration) - as such, updated.