### PR TITLE
Remove redundant `wget` installation in `publish-deb-package.yml`

### DIFF
--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install prerequisites
         run: |
           apt-get update
-          apt-get install -y curl gettext-base gpg sudo wget maven jq
+          apt-get install -y curl gettext-base gpg sudo maven jq
 
       - name: Download the distribution file
         uses: hazelcast/docker-actions/download-hz-dist@master


### PR DESCRIPTION
We install `wget` twice - once in the setup, once immediately before we use it - which is once too many.