### PR TITLE
Remove Maven from CI runners

### DIFF
--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -57,14 +57,13 @@ jobs:
       - name: Install prerequisites
         run: |
           apt-get update
-          apt-get install -y curl gettext-base gpg sudo wget maven jq
+          apt-get install -y curl gettext-base gpg sudo wget jq
 
       - name: Download the distribution file
         uses: hazelcast/docker-actions/download-hz-dist@master
         with:
           environment: ${{ inputs.ENVIRONMENT == 'test' && 'live' || inputs.ENVIRONMENT }}
           aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
-          maven-settings-path: /usr/share/maven/conf/settings.xml
           distribution: ${{ env.HZ_DISTRIBUTION }}
           hz_version: ${{ env.HZ_VERSION }}
           packaging: "tar.gz"

--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -57,7 +57,12 @@ jobs:
       - name: Install prerequisites
         run: |
           apt-get update
-          apt-get install -y curl gettext-base gpg sudo jq
+          apt-get install -y \
+            curl \
+            gettext-base \
+            gpg \
+            jq \
+            sudo
 
       - name: Download the distribution file
         uses: hazelcast/docker-actions/download-hz-dist@master

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -51,14 +51,13 @@ jobs:
 
       - name: Install Required tools
         run: |
-          yum install -y maven rpm-sign rpm-build wget gettext systemd-rpm-macros jq
+          yum install -y rpm-sign rpm-build wget gettext systemd-rpm-macros jq
 
       - name: Download the distribution file
         uses: hazelcast/docker-actions/download-hz-dist@master
         with:
           environment: ${{ inputs.ENVIRONMENT == 'test' && 'live' || inputs.ENVIRONMENT }}
           aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
-          maven-settings-path: /usr/share/maven/conf/settings.xml
           distribution: ${{ env.HZ_DISTRIBUTION }}
           hz_version: ${{ env.HZ_VERSION }}
           packaging: "tar.gz"

--- a/.github/workflows/publish-rpm-package.yml
+++ b/.github/workflows/publish-rpm-package.yml
@@ -51,7 +51,14 @@ jobs:
 
       - name: Install Required tools
         run: |
-          yum install -y rpm-sign rpm-build wget gettext systemd-rpm-macros jq
+          yum install -y \
+            gettext \
+            jq \
+            rpm-build \
+            rpm-sign \
+            systemd-rpm-macros \
+            wget \
+            which
 
       - name: Download the distribution file
         uses: hazelcast/docker-actions/download-hz-dist@master


### PR DESCRIPTION
We used to install Maven because [`download-hz-dist`](https://github.com/hazelcast/docker-actions/blob/master/download-hz-dist/action.yml) used it, but now it doesn't since https://github.com/hazelcast/docker-actions/pull/67 and it's no longer required.