### PR TITLE
Remove `DISTINCT_ID` release workflow inputs

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,21 +20,8 @@ on:
         description: 'Environment to use'
         required: true
         type: environment
-      distinct_id:
-        description: 'Required exclusively for automated execution to track status of workflow execution'
-        required: false
 
 jobs:
-  log-distinct-id:
-    runs-on: ubuntu-slim
-    if: inputs.distinct_id != ''
-    steps:
-        # https://github.com/Codex-/return-dispatch#receiving-repository-action
-      - name: Logging distinct ID (${{ inputs.distinct_id }})
-        run: echo "${DISTINCT_ID}"
-        env:
-          DISTINCT_ID: ${{ inputs.distinct_id }}
-
   package:
     uses: ./.github/workflows/publish-packages.yml
     with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -19,9 +19,6 @@ on:
         description: 'Environment to use'
         required: true
         type: environment
-      distinct_id:
-        description: 'Required exclusively for automated execution to track status of workflow execution'
-        required: false
 
 jobs:
   prepare:
@@ -29,12 +26,6 @@ jobs:
     outputs:
       distribution-types: ${{ steps.distribution-type-matrix.outputs.matrix }}
     steps:
-        # https://github.com/Codex-/return-dispatch#receiving-repository-action
-      - name: Logging distinct ID (${{ inputs.distinct_id }})
-        run: echo "${DISTINCT_ID}"
-        env:
-          DISTINCT_ID: ${{ inputs.distinct_id }}
-
       - id: resolve-editions
         uses: hazelcast/docker-actions/resolve-editions@master
         with:


### PR DESCRIPTION
No longer required since https://github.com/Codex-/return-dispatch/releases/tag/v4.0.0, as [GitHub now has built in functionality to support](https://github.blog/changelog/2026-02-19-workflow-dispatch-api-now-returns-run-ids/).