### PR TITLE
Move to Hazelcast 6.0 development cycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-packaging</artifactId>
-    <version>5.8.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <description>A pom.xml file to define the project version.</description>
 </project>


### PR DESCRIPTION
At the back of https://github.com/hazelcast/hazelcast-mono/pull/7393
Normally, the Release Pipeline does this update during release branch creation
But we have agreed to update manually